### PR TITLE
Improve performance when target is a file

### DIFF
--- a/src/burn/ipc.rs
+++ b/src/burn/ipc.rs
@@ -4,12 +4,15 @@ use serde::{Deserialize, Serialize};
 
 use valuable::Valuable;
 
+use crate::device::Type;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Valuable)]
 pub struct BurnConfig {
     pub dest: PathBuf,
     pub src: PathBuf,
     pub logfile: PathBuf,
     pub verify: bool,
+    pub target_type: Type,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Valuable)]

--- a/src/device.rs
+++ b/src/device.rs
@@ -6,6 +6,8 @@ use std::{
 };
 
 use bytesize::ByteSize;
+use serde::{Serialize, Deserialize};
+use valuable::Valuable;
 
 #[cfg(target_os = "linux")]
 pub fn enumerate_devices() -> impl Iterator<Item = BurnTarget> {
@@ -293,7 +295,7 @@ impl Display for Removable {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Valuable)]
 pub enum Type {
     File,
     Disk,

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,7 @@ async fn inner_main() -> anyhow::Result<()> {
         src: args.input.to_owned(),
         logfile: get_log_paths().child.clone(),
         verify: true,
+        target_type: target.target_type,
     };
 
     let handle = try_start_burn(&burn_args).await?;


### PR DESCRIPTION
Basically, don't turn on O_SYNC for the filesystem.