### PR TITLE
Add support for compressed input files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static_cell",
+ "strum",
  "test-case",
  "thiserror",
  "tokio",
@@ -989,6 +990,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1130,6 +1137,28 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,6 @@ dependencies = [
  "serde",
  "serde_json",
  "static_cell",
- "strum",
  "test-case",
  "thiserror",
  "tokio",
@@ -179,7 +178,6 @@ dependencies = [
  "tracing-unwrap",
  "tui",
  "valuable",
- "xz",
  "xz2",
 ]
 
@@ -991,12 +989,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
-
-[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,28 +1130,6 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
-]
 
 [[package]]
 name = "syn"
@@ -1541,15 +1511,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
-
-[[package]]
-name = "xz"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c887690ff2a2e233e8e49633461521f98ec57fbff9d59a884c9a4f04ec1da34"
-dependencies = [
- "xz2",
-]
 
 [[package]]
 name = "xz2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,6 +125,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38fcc2979eff34a4b84e1cf9a1e3da42a7d44b3b690a40cdcb23e3d556cfb2e5"
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "caligula"
 version = "0.2.0-pre1"
 dependencies = [
@@ -126,8 +153,10 @@ dependencies = [
  "approx",
  "bindgen",
  "bytesize",
+ "bzip2",
  "clap",
  "crossterm 0.26.1",
+ "flate2",
  "format-bytes",
  "futures",
  "futures-io",
@@ -149,6 +178,7 @@ dependencies = [
  "tracing-unwrap",
  "tui",
  "valuable",
+ "xz",
 ]
 
 [[package]]
@@ -233,6 +263,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -338,6 +377,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -636,6 +685,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +706,15 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -771,6 +840,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "ppv-lite86"
@@ -1436,3 +1511,21 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "xz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c887690ff2a2e233e8e49633461521f98ec57fbff9d59a884c9a4f04ec1da34"
+dependencies = [
+ "xz2",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,7 @@ dependencies = [
  "tui",
  "valuable",
  "xz",
+ "xz2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,10 @@ license = "GPL-3.0"
 [dependencies]
 anyhow = "1.0.69"
 bytesize = "1.2.0"
+bzip2 = "0.4.4"
 clap = { version = "4.1.8", features = ["derive", "cargo"] }
 crossterm = { version = "0.26.1", features = ["event-stream"] }
+flate2 = "1.0.25"
 format-bytes = "0.3.0"
 futures = "0.3.26"
 futures-io = "0.3.26"
@@ -29,6 +31,7 @@ tracing-subscriber = "0.3.16"
 tracing-unwrap = "0.10.0"
 tui = "0.19.0"
 valuable = { version = "0.1.0", features = ["derive"] }
+xz = "0.1.0"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,19 @@ version = "0.2.0-pre1"
 edition = "2021"
 license = "GPL-3.0"
 
+[features]
+default = ["gz", "xz", "bz2"]
+gz = ["dep:flate2"]
+xz = ["dep:xz2"]
+bz2 = ["dep:bzip2"]
+
 [dependencies]
 anyhow = "1.0.69"
 bytesize = "1.2.0"
-bzip2 = { version = "0.4.4", features = ["static"] }
+bzip2 = { version = "0.4.4", optional = true, features = ["static"] }
 clap = { version = "4.1.8", features = ["derive", "cargo"] }
 crossterm = { version = "0.26.1", features = ["event-stream"] }
-flate2 = "1.0.25"
+flate2 = { version = "1.0.25", optional = true }
 format-bytes = "0.3.0"
 futures = "0.3.26"
 futures-io = "0.3.26"
@@ -23,17 +29,20 @@ rand = "0.8.5"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 static_cell = "1.0.0"
-strum = { version = "0.24.1", features = ["derive"] }
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["full"] }
 tokio-util = { version = "0.7.7", features = ["compat"] }
-tracing = { version = "0.1.37", features = ["async-await", "log", "release_max_level_debug", "valuable"] }
+tracing = { version = "0.1.37", features = [
+    "async-await",
+    "log",
+    "release_max_level_debug",
+    "valuable",
+] }
 tracing-subscriber = "0.3.16"
 tracing-unwrap = "0.10.0"
 tui = "0.19.0"
 valuable = { version = "0.1.0", features = ["derive"] }
-xz = "0.1.0"
-xz2 = { version = "0.1.7", features = ["static"] }
+xz2 = { version = "0.1.7", optional = true, features = ["static"] }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rand = "0.8.5"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"
 static_cell = "1.0.0"
+strum = { version = "0.24.1", features = ["derive"] }
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["full"] }
 tokio-util = { version = "0.7.7", features = ["compat"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 [dependencies]
 anyhow = "1.0.69"
 bytesize = "1.2.0"
-bzip2 = "0.4.4"
+bzip2 = { version = "0.4.4", features = ["static"] }
 clap = { version = "4.1.8", features = ["derive", "cargo"] }
 crossterm = { version = "0.26.1", features = ["event-stream"] }
 flate2 = "1.0.25"
@@ -33,6 +33,7 @@ tracing-unwrap = "0.10.0"
 tui = "0.19.0"
 valuable = { version = "0.1.0", features = ["derive"] }
 xz = "0.1.0"
+xz2 = { version = "0.1.7", features = ["static"] }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
         devShell = let tc = crossHelpers.forTarget system;
         in with pkgs;
         mkShell {
-          buildInputs = [ nixfmt tc.rust-toolchain-dev ] ++ tc.platformDeps;
+          buildInputs = [ nixfmt tc.rust-toolchain-dev ] ++ tc.buildInputs;
           CARGO_BUILD_TARGET = tc.rustTarget;
         };
       }));

--- a/nix/cross-helpers.nix
+++ b/nix/cross-helpers.nix
@@ -63,6 +63,9 @@ in rec {
         "${cargoTargetPrefix}_LINKER" =
           "${pkgsCross.stdenv.cc}/bin/${buildCfg.rustTarget}-ld";
         CARGO_BUILD_TARGET = buildCfg.rustTarget;
+
+        # Disable xz and bz because native cross-compile is borked
+        cargoOptions = [ "--no-default-features" "-F" "gz" ];
       } else
         { };
 

--- a/src/burn/child.rs
+++ b/src/burn/child.rs
@@ -1,3 +1,4 @@
+use std::io::BufReader;
 use std::panic::set_hook;
 use std::{
     env,
@@ -85,8 +86,8 @@ impl Ctx {
         };
         self.send_msg(StatusMessage::InitSuccess(InitialInfo { input_file_bytes }));
 
-        for_each_block(self, src, |offset, block, _| {
-            trace!(offset, block_len = block.len(), "Writing block");
+        for_each_block(self, src, |block, _| {
+            trace!(block_len = block.len(), "Writing block");
 
             let written = dest.write(block).expect("Failed to write block to disk");
             if written != block.len() {
@@ -103,8 +104,8 @@ impl Ctx {
         );
 
         let mut dest = File::open(&self.args.dest)?;
-        for_each_block(self, src, |offset, block, dst| {
-            trace!(offset, block_len = block.len(), "Verifying block");
+        for_each_block(self, src, |block, dst| {
+            trace!(block_len = block.len(), "Verifying block");
 
             let read = dest.read(dst).expect("Failed to read block from disk");
             if read != block.len() {
@@ -126,33 +127,32 @@ impl Ctx {
 fn for_each_block(
     ctx: &mut Ctx,
     src: &mut File,
-    mut action: impl FnMut(usize, &[u8], &mut [u8]) -> Result<(), ErrorType>,
+    mut action: impl FnMut(&[u8], &mut [u8]) -> Result<(), ErrorType>,
 ) -> Result<(), ErrorType> {
     let block_size = ByteSize::kb(128).as_u64() as usize;
     let mut full_block = vec![0u8; block_size];
     let mut closure_block = vec![0u8; block_size]; // A block for the user to mutate
 
-    let mut offset: usize = 0;
+    let mut decompress = ctx.args.compression.decompress(BufReader::new(src));
 
     let checkpoint_blocks: usize = 32;
+    let mut offset: u64 = 0;
 
     loop {
         for _ in 0..checkpoint_blocks {
-            let read_bytes = src.read(&mut full_block)?;
+            let read_bytes = decompress.read(&mut full_block)?;
             if read_bytes == 0 {
                 return Ok(());
             }
 
-            action(
-                offset,
-                &full_block[..read_bytes],
-                &mut closure_block[..read_bytes],
-            )?;
-
-            offset += read_bytes;
+            action(&full_block[..read_bytes], &mut closure_block[..read_bytes])?;
+            offset += read_bytes as u64;
         }
 
-        ctx.send_msg(StatusMessage::TotalBytes(offset));
+        ctx.send_msg(StatusMessage::TotalBytes {
+            src: decompress.get_mut().stream_position()?,
+            dest: offset,
+        });
     }
 }
 

--- a/src/burn/child.rs
+++ b/src/burn/child.rs
@@ -12,6 +12,7 @@ use interprocess::local_socket::LocalSocketStream;
 use tracing::{debug, error, info, trace};
 use tracing_unwrap::ResultExt;
 
+use crate::compression::decompress;
 use crate::device;
 use crate::logging::init_logging_child;
 
@@ -133,7 +134,7 @@ fn for_each_block(
     let mut full_block = vec![0u8; block_size];
     let mut closure_block = vec![0u8; block_size]; // A block for the user to mutate
 
-    let mut decompress = ctx.args.compression.decompress(BufReader::new(src));
+    let mut decompress = decompress(ctx.args.compression, BufReader::new(src)).unwrap();
 
     let checkpoint_blocks: usize = 32;
     let mut offset: u64 = 0;

--- a/src/burn/ipc.rs
+++ b/src/burn/ipc.rs
@@ -4,12 +4,15 @@ use serde::{Deserialize, Serialize};
 
 use valuable::Valuable;
 
+use crate::compression::CompressionFormat;
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Valuable)]
 pub struct BurnConfig {
     pub dest: PathBuf,
     pub src: PathBuf,
     pub logfile: PathBuf,
     pub verify: bool,
+    pub compression: CompressionFormat,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Valuable)]

--- a/src/burn/ipc.rs
+++ b/src/burn/ipc.rs
@@ -22,7 +22,7 @@ pub enum StatusMessage {
     InitSuccess(InitialInfo),
     TotalBytes {
         src: u64,
-        dest: u64
+        dest: u64,
     },
     FinishedWriting {
         verifying: bool,

--- a/src/burn/ipc.rs
+++ b/src/burn/ipc.rs
@@ -20,7 +20,10 @@ pub struct BurnConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Valuable)]
 pub enum StatusMessage {
     InitSuccess(InitialInfo),
-    TotalBytes(usize),
+    TotalBytes {
+        src: u64,
+        dest: u64
+    },
     FinishedWriting {
         verifying: bool,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -64,6 +64,8 @@ fn parse_path_exists(p: &str) -> Result<PathBuf, String> {
 }
 
 impl CompressionArg {
+    /// Detect what compression format to use. If we couldn't figure it out,
+    /// returns None.
     pub fn detect_format(&self, path: impl AsRef<Path>) -> Option<CompressionFormat> {
         match self {
             CompressionArg::Auto => {

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,9 +1,14 @@
-use std::io::{BufRead, Read};
+use std::{
+    fmt::Display,
+    io::{BufRead, Read},
+};
 
 use bzip2::bufread::BzDecoder;
 use flate2::bufread::GzDecoder;
+use serde::{Deserialize, Serialize};
 use xz::bufread::XzDecoder;
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CompressionFormat {
     Identity,
     Gzip,
@@ -66,3 +71,14 @@ decompress_read!(
         Xz(XzDecoder<R>),
     }
 );
+
+impl Display for CompressionFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CompressionFormat::Identity => write!(f, "no compression"),
+            CompressionFormat::Gzip => write!(f, "gzip"),
+            CompressionFormat::Bzip2 => write!(f, "bzip2"),
+            CompressionFormat::Xz => write!(f, "xz/lzma"),
+        }
+    }
+}

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -6,9 +6,11 @@ use std::{
 use bzip2::bufread::BzDecoder;
 use flate2::bufread::GzDecoder;
 use serde::{Deserialize, Serialize};
+use strum::EnumIter;
+use valuable::Valuable;
 use xz::bufread::XzDecoder;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, EnumIter, Valuable)]
 pub enum CompressionFormat {
     Identity,
     Gzip,
@@ -18,14 +20,11 @@ pub enum CompressionFormat {
 
 impl CompressionFormat {
     pub fn detect_from_extension(ext: &str) -> Self {
-        match ext.to_lowercase().strip_prefix(".") {
-            Some(ext) => match ext {
-                "gz" => Self::Gzip,
-                "xz" => Self::Xz,
-                "bz2" => Self::Bzip2,
-                _ => Self::Identity,
-            },
-            None => Self::Identity,
+        match ext.to_lowercase().trim_start_matches(".") {
+            "gz" => Self::Gzip,
+            "xz" => Self::Xz,
+            "bz2" => Self::Bzip2,
+            _ => Self::Identity,
         }
     }
 
@@ -78,7 +77,7 @@ impl Display for CompressionFormat {
             CompressionFormat::Identity => write!(f, "no compression"),
             CompressionFormat::Gzip => write!(f, "gzip"),
             CompressionFormat::Bzip2 => write!(f, "bzip2"),
-            CompressionFormat::Xz => write!(f, "xz/lzma"),
+            CompressionFormat::Xz => write!(f, "LZMA (xz)"),
         }
     }
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -8,7 +8,7 @@ use flate2::bufread::GzDecoder;
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
 use valuable::Valuable;
-use xz::bufread::XzDecoder;
+use xz2::bufread::XzDecoder;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, EnumIter, Valuable)]
 pub enum CompressionFormat {

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -28,7 +28,7 @@ impl CompressionFormat {
         }
     }
 
-    pub fn decompress<R>(&self, r: R) -> DecompressRead<R>
+    pub fn decompress<R>(self, r: R) -> DecompressRead<R>
     where
         R: BufRead,
     {
@@ -37,6 +37,13 @@ impl CompressionFormat {
             CompressionFormat::Gzip => DecompressRead::Gzip(GzDecoder::new(r)),
             CompressionFormat::Bzip2 => DecompressRead::Bzip2(BzDecoder::new(r)),
             CompressionFormat::Xz => DecompressRead::Xz(XzDecoder::new(r)),
+        }
+    }
+
+    pub fn is_identity(self) -> bool {
+        match self {
+            CompressionFormat::Identity => true,
+            _ => false,
         }
     }
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,0 +1,68 @@
+use std::io::{BufRead, Read};
+
+use bzip2::bufread::BzDecoder;
+use flate2::bufread::GzDecoder;
+use xz::bufread::XzDecoder;
+
+pub enum CompressionFormat {
+    Identity,
+    Gzip,
+    Bzip2,
+    Xz,
+}
+
+impl CompressionFormat {
+    pub fn detect_from_extension(ext: &str) -> Self {
+        match ext.to_lowercase().strip_prefix(".") {
+            Some(ext) => match ext {
+                "gz" => Self::Gzip,
+                "xz" => Self::Xz,
+                "bz2" => Self::Bzip2,
+                _ => Self::Identity,
+            },
+            None => Self::Identity,
+        }
+    }
+
+    pub fn decompress(&self, r: impl BufRead) -> impl Read {
+        match self {
+            CompressionFormat::Identity => DecompressRead::Identity(r),
+            CompressionFormat::Gzip => DecompressRead::Gzip(GzDecoder::new(r)),
+            CompressionFormat::Bzip2 => DecompressRead::Bzip2(BzDecoder::new(r)),
+            CompressionFormat::Xz => DecompressRead::Xz(XzDecoder::new(r)),
+        }
+    }
+}
+
+macro_rules! decompress_read {
+    (
+        $name:ident <$var:ident> {
+            $( $enumname:ident ($inner:ty), )*
+        }
+    ) => {
+        enum $name<$var> where $var : BufRead {
+            $(
+                $enumname($inner),
+            )*
+        }
+
+        impl<R> Read for DecompressRead<R> where R : BufRead {
+            fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+                match self {
+                    $(
+                        Self::$enumname(r) => r.read(buf),
+                    )*
+                }
+            }
+        }
+    };
+}
+
+decompress_read!(
+    DecompressRead<R> {
+        Identity(R),
+        Gzip(GzDecoder<R>),
+        Bzip2(BzDecoder<R>),
+        Xz(XzDecoder<R>),
+    }
+);

--- a/src/device.rs
+++ b/src/device.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bytesize::ByteSize;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use valuable::Valuable;
 
 #[cfg(target_os = "linux")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use burn::{
 };
 use clap::Parser;
 use cli::{Args, BurnArgs, Command};
+use compression::CompressionFormat;
 use device::BurnTarget;
 use inquire::{Confirm, InquireError};
 use tracing::debug;
@@ -82,7 +83,7 @@ async fn inner_main() -> anyhow::Result<()> {
 
     let handle = try_start_burn(&burn_args).await?;
 
-    begin_writing(target, handle, &args).await?;
+    begin_writing(target, handle, compression, &args).await?;
 
     debug!("Done!");
     Ok(())
@@ -121,6 +122,7 @@ async fn try_start_burn(args: &BurnConfig) -> anyhow::Result<burn::Handle> {
 async fn begin_writing(
     target: BurnTarget,
     handle: burn::Handle,
+    cf: CompressionFormat,
     args: &BurnArgs,
 ) -> anyhow::Result<()> {
     debug!("Opening TUI");
@@ -128,7 +130,7 @@ async fn begin_writing(
     let terminal = tui.terminal();
 
     // create app and run it
-    ui::burn::UI::new(handle, terminal, target, args)
+    ui::burn::UI::new(handle, terminal, target, cf, args)
         .show()
         .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod device;
 pub mod logging;
 pub mod native;
 mod ui;
+mod compression;
 
 fn main() {
     if is_in_burn_mode() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,11 +16,11 @@ use ui::{confirm_write, utils::TUICapture};
 
 pub mod burn;
 pub mod cli;
+mod compression;
 mod device;
 pub mod logging;
 pub mod native;
 mod ui;
-mod compression;
 
 fn main() {
     if is_in_burn_mode() {

--- a/src/ui/ask_outfile.rs
+++ b/src/ui/ask_outfile.rs
@@ -84,15 +84,12 @@ pub fn confirm_write(
     } else {
         let input_size = ByteSize::b(File::open(&args.input)?.metadata()?.len());
         println!("Input: {}", args.input.to_string_lossy());
-        match compression {
-            CompressionFormat::Identity => {
-                println!("  Size: {}", input_size);
-                println!("  Compression: {}", compression);
-            }
-            _ => {
-                println!("  Size (compressed): {}", input_size);
-                println!("  Compression: {}", compression);
-            }
+        if compression.is_identity() {
+            println!("  Size: {}", input_size);
+            println!("  Compression: {}", compression);
+        } else {
+            println!("  Size (compressed): {}", input_size);
+            println!("  Compression: {}", compression);
         }
         println!();
 

--- a/src/ui/burn/byteseries.rs
+++ b/src/ui/burn/byteseries.rs
@@ -142,7 +142,7 @@ mod tests {
 
     fn example_2s() -> ByteSeries {
         let now = Instant::now();
-        let mut s = ByteSeries::new(now, ByteSize::b(100));
+        let mut s = ByteSeries::new(now);
         s.push(now.checked_add(Duration::from_secs_f64(0.1)).unwrap(), 10);
         s.push(now.checked_add(Duration::from_secs_f64(0.2)).unwrap(), 20);
         s.push(now.checked_add(Duration::from_secs_f64(0.5)).unwrap(), 30);

--- a/src/ui/burn/display.rs
+++ b/src/ui/burn/display.rs
@@ -14,10 +14,9 @@ use tui::{
 use crate::{
     burn::{self, Handle},
     cli::BurnArgs,
-    compression::CompressionFormat,
     device::BurnTarget,
     logging::get_bug_report_msg,
-    ui::burn::state::UIEvent,
+    ui::burn::state::UIEvent, compression::CompressionFormat,
 };
 
 use super::{

--- a/src/ui/burn/state.rs
+++ b/src/ui/burn/state.rs
@@ -11,6 +11,8 @@ use crate::{
     ui::burn::byteseries::ByteSeries,
 };
 
+use super::history::UIState;
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum UIEvent {
     SleepTimeout,
@@ -23,6 +25,7 @@ pub struct State {
     pub input_filename: String,
     pub target_filename: String,
     pub child: ChildState,
+    pub ui_state: UIState,
 }
 
 #[derive(Debug)]

--- a/src/ui/burn/state.rs
+++ b/src/ui/burn/state.rs
@@ -73,8 +73,8 @@ impl State {
 
     fn on_child_status(mut self, now: Instant, msg: Option<StatusMessage>) -> Self {
         match msg {
-            Some(StatusMessage::TotalBytes(b)) => {
-                self.child.on_total_bytes(now, b as u64);
+            Some(StatusMessage::TotalBytes { src, dest }) => {
+                self.child.on_total_bytes(now, src, dest);
                 self
             }
             Some(StatusMessage::FinishedWriting { verifying }) => {
@@ -131,10 +131,10 @@ impl State {
 }
 
 impl ChildState {
-    pub fn on_total_bytes(&mut self, now: Instant, bytes: u64) {
+    pub fn on_total_bytes(&mut self, now: Instant, src: u64, dest: u64) {
         match self {
-            ChildState::Burning { write_hist, .. } => write_hist.push(now, bytes),
-            ChildState::Verifying { verify_hist, .. } => verify_hist.push(now, bytes),
+            ChildState::Burning { write_hist, .. } => write_hist.push(now, src),
+            ChildState::Verifying { verify_hist, .. } => verify_hist.push(now, dest),
             ChildState::Finished { .. } => {}
         };
     }


### PR DESCRIPTION
Closes #4 .
This adds support for gz, xz, and bz2 compression formats.
Since cross-compiling C using naersk is pain, I'm disabling xz and bz2 on aarch64-linux for the time being.