### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
-name: "Publish package"
+name: "Publish pipeline"
 
 on:
+  push:
   workflow_dispatch:
   release:
     types: [published]
@@ -12,15 +13,26 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: cachix/install-nix-action@v22
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/cachix-action@v12
+        with:
+          name: astralbijection
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
       - name: Generate PKGBUILD
-        run: nix build .#caligula-bin-aur
+        run: |
+          nix build .#caligula-bin-aur
+          cat result/PKGBUILD
+          cp result/PKGBUILD .
 
       - name: Publish AUR package
         uses: KSXGitHub/github-actions-deploy-aur@v2
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'release' }}
         with:
           pkgname: caligula-bin
-          pkgbuild: ./result/PKGBUILD
-          test: true
+          pkgbuild: ./PKGBUILD
           commit_username: ifd3f
           commit_email: astrid@astrid.tech
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}


### PR DESCRIPTION
#76 didn't actually work. This makes it actually work.

# Test plan

[Manual action run](https://github.com/ifd3f/caligula/actions/runs/6834136180) created [this AUR update](https://aur.archlinux.org/cgit/aur.git/commit/?h=caligula-bin&id=eb07e59bccff29b117b70bd1bd39f8588d7d8aae).