### PR TITLE
Add lz4 decompression support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.img
 *.iso
 *.xz
+*.lz4
 *.gz
 *.o
 *.a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "is-terminal",
  "itertools",
  "libc",
+ "lz4_flex",
  "md-5",
  "process_path",
  "rand",
@@ -882,6 +883,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
  "hashbrown",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -1649,6 +1659,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4e33415be97f5ae70322d6fefc696bbc08887d8835400d6c77f059469b30354"
 dependencies = [
  "tracing",
+]
+
+[[package]]
+name = "twox-hash"
+version = "1.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
+dependencies = [
+ "cfg-if",
+ "static_assertions",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ interprocess = { version = "2.0.0", features = ["tokio"] }
 is-terminal = "0.4.12"
 itertools = "0.12.1"
 libc = "0.2.154"
+lz4_flex = "0.11.3"
 md-5 = "0.10.5"
 process_path = "0.1.4"
 ratatui = "0.26.0"

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -87,7 +87,7 @@ macro_rules! generate {
             }
         }
 
-        pub enum DecompressRead<$r> {
+        pub enum DecompressRead<$r: BufRead> {
             Identity($r),
             $(
                 $enumarm($inner),
@@ -149,6 +149,9 @@ generate! {
         },
         "xz" => Xz("xz/LZMA", xz2::bufread::XzDecoder<R>) {
             xz2::bufread::XzDecoder::new(r)
+        },
+        "lz4" => Lz4("lz4", lz4_flex::frame::FrameDecoder<R>) {
+            lz4_flex::frame::FrameDecoder::new(r)
         },
     }
 }


### PR DESCRIPTION
Closes #106.

## Test plan (writing to a file) 

Using [duo256_sd.img.lz4](https://github.com/Fishwaldo/sophgo-sg200x-debian/releases) as mentioned in the issue:

```
% cargo run -- burn duo256_sd.img.lz4 -o dst2.iso --hash none
   Compiling twox-hash v1.6.3
   Compiling caligula v0.4.4 (/home/astrid/Documents/caligula)
   Compiling lz4_flex v0.11.3
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.95s
     Running `target/debug/caligula burn duo256_sd.img.lz4 -o dst2.iso --hash none`
Input file: duo256_sd.img.lz4
Detected compression format: lz4
> Is this okay? Yes
Input: duo256_sd.img.lz4
  Size (compressed): 188.5 MB
  Compression: lz4

Output: dst2.iso
  Model: [unknown model]
  Size: [unknown size]
  Type: file
  Path: dst2.iso
  Removable: unknown

> Is this okay? Yes
```

Write worked, and so did verification.

Correctness validation:

```
% lz4 -d < duo256_sd.img.lz4 > a.img
% diff a.img dst2.iso -s
Files a.img and dst2.iso are identical
```