### PR TITLE
Add zstd decompression support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.log
 *.img
 *.iso
+*.zst
 *.xz
 *.lz4
 *.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,7 @@ dependencies = [
  "valuable",
  "which 6.0.1",
  "xz2",
+ "zstd",
 ]
 
 [[package]]
@@ -301,6 +302,11 @@ name = "cc"
 version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
+dependencies = [
+ "jobserver",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "cexpr"
@@ -825,6 +831,15 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jobserver"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1957,4 +1972,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.10+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,7 @@ dependencies = [
  "process_path",
  "rand",
  "ratatui",
+ "ruzstd",
  "serde",
  "serde_json",
  "sha1",
@@ -279,7 +280,6 @@ dependencies = [
  "valuable",
  "which 6.0.1",
  "xz2",
- "zstd",
 ]
 
 [[package]]
@@ -302,11 +302,6 @@ name = "cc"
 version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "065a29261d53ba54260972629f9ca6bffa69bac13cd1fed61420f7fa68b9f8bd"
-dependencies = [
- "jobserver",
- "libc",
- "once_cell",
-]
 
 [[package]]
 name = "cexpr"
@@ -833,15 +828,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "jobserver"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1288,6 +1274,15 @@ name = "rustversion"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+
+[[package]]
+name = "ruzstd"
+version = "0.6.0"
+source = "git+https://github.com/ifd3f/zstd-rs.git?rev=4b79cb9091b7ae2db110b4e3f0abdf2bd60fd625#4b79cb9091b7ae2db110b4e3f0abdf2bd60fd625"
+dependencies = [
+ "byteorder",
+ "twox-hash",
+]
 
 [[package]]
 name = "ryu"
@@ -1972,32 +1967,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.60",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.10+zstd.1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ lz4_flex = "0.11.3"
 md-5 = "0.10.5"
 process_path = "0.1.4"
 ratatui = "0.26.0"
+ruzstd = { git = "https://github.com/ifd3f/zstd-rs.git", rev = "4b79cb9091b7ae2db110b4e3f0abdf2bd60fd625", version = "0.6.0" }
 serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0.116"
 sha1 = "0.10.5"
@@ -52,7 +53,6 @@ tracing-unwrap = "1.0.1"
 valuable = { version = "0.1.0", features = ["derive"] }
 which = "6.0.1"
 xz2 = { version = "0.1.7", features = ["static"] }
-zstd = "0.13.1"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ tracing-unwrap = "1.0.1"
 valuable = { version = "0.1.0", features = ["derive"] }
 which = "6.0.1"
 xz2 = { version = "0.1.7", features = ["static"] }
+zstd = "0.13.1"
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -154,7 +154,7 @@ generate! {
             lz4_flex::frame::FrameDecoder::new(r)
         },
         "zst" => Zst("zstd/Zstandard", zstd::stream::read::Decoder<'static, R>) {
-            zstd::stream::read::Decoder::with_buffer(r).unwrap()
+            zstd::stream::read::Decoder::with_buffer(r)?
         },
     }
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -153,8 +153,8 @@ generate! {
         "lz4" => Lz4("lz4", lz4_flex::frame::FrameDecoder<R>) {
             lz4_flex::frame::FrameDecoder::new(r)
         },
-        "zst" => Zst("zstd/Zstandard", zstd::stream::read::Decoder<'static, R>) {
-            zstd::stream::read::Decoder::with_buffer(r)?
+        "zst" => Zst("zstd/Zstandard", ruzstd::streaming_decoder::StreamingDecoder<R, ruzstd::frame_decoder::FrameDecoder>) {
+            ruzstd::streaming_decoder::StreamingDecoder::new(r)?
         },
     }
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -153,6 +153,9 @@ generate! {
         "lz4" => Lz4("lz4", lz4_flex::frame::FrameDecoder<R>) {
             lz4_flex::frame::FrameDecoder::new(r)
         },
+        "zst" => Zst("zstd/Zstandard", zstd::stream::read::Decoder<'static, R>) {
+            zstd::stream::read::Decoder::with_buffer(r).unwrap()
+        },
     }
 }
 


### PR DESCRIPTION
Closes #117

Test plan (writing to a file)

```
$ target/debug/caligula burn ~/downloads/duos_sd.img.zst -o /tmp/new.img
Input file: /home/felix/downloads/duos_sd.img.zst
Detected compression format: zstd
> Is this okay? Yes
? What is the file's hash? <canceled>
Input: /home/felix/downloads/duos_sd.img.zst
  Size (compressed): 152.3 MB
  Compression: zstd

Output: /tmp/new.img
  Model: [unknown model]
  Size: [unknown size]
  Type: file
  Path: /tmp/new.img
  Removable: unknown

> Is this okay? Yes
```

Write worked, and so did verification.

Correctness validation:

```
$ sha256sum duos_sd.img
a7e0190a6067d6307a6d90e2bc2dd0653125a1d03b5f6fde96d74bd1544f2294  duos_sd.img
$ sha256sum /tmp/new.img
a7e0190a6067d6307a6d90e2bc2dd0653125a1d03b5f6fde96d74bd1544f2294  /tmp/new.img
```