### PR TITLE
Bandaid for #107 by storing termios state

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod ipc_common;
 mod logging;
 mod native;
 mod run_mode;
+mod tty;
 mod ui;
 mod util;
 mod writer_process;

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -1,0 +1,42 @@
+use std::{mem, os::fd::AsRawFd};
+
+use libc::{c_int, tcsetattr, termios, TCSANOW};
+use tracing::info;
+
+/// Stores the state of the terminal when created, and restores it on drop
+pub struct TermiosRestore<F: AsRawFd> {
+    term_orig: termios,
+    file: F,
+}
+
+impl<F: AsRawFd> TermiosRestore<F> {
+    pub fn new(file: F) -> std::io::Result<TermiosRestore<F>> {
+        info!("attempting to store terminal state before program started");
+        let fd = file.as_raw_fd();
+        let term_orig = safe_tcgetattr(fd)?;
+        Ok(TermiosRestore { file, term_orig })
+    }
+}
+
+impl<F: AsRawFd> Drop for TermiosRestore<F> {
+    fn drop(&mut self) {
+        info!("restoring terminal state to what it was before program started");
+        unsafe {
+            tcsetattr(self.file.as_raw_fd(), TCSANOW, &self.term_orig);
+        }
+    }
+}
+
+/// Turns a C function return into an IO Result
+fn io_result(ret: c_int) -> std::io::Result<()> {
+    match ret {
+        0 => Ok(()),
+        _ => Err(std::io::Error::last_os_error()),
+    }
+}
+
+fn safe_tcgetattr(fd: c_int) -> std::io::Result<termios> {
+    let mut term = mem::MaybeUninit::<termios>::uninit();
+    io_result(unsafe { ::libc::tcgetattr(fd, term.as_mut_ptr()) })?;
+    Ok(unsafe { term.assume_init() })
+}


### PR DESCRIPTION
Improves #107, but doesn't fully fix the issue, by using a very simple hack. Technically the terminal output is still screwed up, but terminal output after the program ends is still fine.

# Test plan

## Before

```
> cargo run burn LICENSE -o /tmp/testfile -s none -z none
   Compiling caligula v0.4.4 (/home/astrid/Documents/caligula)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.49s
     Running `target/debug/caligula burn LICENSE -o /tmp/testfile -s none -z none`
Input file: LICENSE
Detected compression format: no compression
Input: LICENSE
  Size: 35.1 KB
  Compression: no compression

Output: /tmp/testfile
  Model: [unknown model]
  Size: [unknown size]
  Type: file
  Path: /tmp/testfile
  Removable: unknown

> Is this okay? Yes
> We don't have permissions on /tmp/testfile. Escalate using sudo? Yes
An unexpected error occurred: panicked at src/ui/main.rs:39:9:
                                                              Explicit failure signaled: Some(PermissionDenied)

                                                                                                               Please report bugs to https://github.com/ifd3f/caligula/issues and attach the log files in dev
                                                                       %                                                              

> ls
build.rs    Cargo.toml  CONTRIBUTING.md  dev         flake.nix  LICENSE  nix        README.md  shell.nix  target
                                                                                                                Cargo.lock  checks      default.nix      flake.lock  images     native   packaging  scripts    src
                                                                            %                                                         

main *8 .................................................................................................. direnv nix impure 22:38:30
                                                                                                                                     astrid@banana ~/Documents/caligula > 
```

The terminal is unusable afterwards.

## After

```
> cargo run burn LICENSE -o /tmp/testfile -s none -z none
   Compiling caligula v0.4.4 (/home/astrid/Documents/caligula)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.16s
     Running `target/debug/caligula burn LICENSE -o /tmp/testfile -s none -z none`
Input file: LICENSE
Detected compression format: no compression
Input: LICENSE
  Size: 35.1 KB
  Compression: no compression

Output: /tmp/testfile
  Model: [unknown model]
  Size: [unknown size]
  Type: file
  Path: /tmp/testfile
  Removable: unknown

> Is this okay? Yes
> We don't have permissions on /tmp/testfile. Escalate using sudo? Yes
[sudo] password for astrid: 
An unexpected error occurred: panicked at src/ui/main.rs:51:9:
                                                              Explicit failure signaled: Some(PermissionDenied)

                                                                                                               Please report bugs to https://github.com/ifd3f/caligula/issues and attach the log files in dev
                                                                       %                                                              
> ls
build.rs    Cargo.toml  CONTRIBUTING.md  dev         flake.nix  LICENSE  nix        README.md  shell.nix  target
Cargo.lock  checks      default.nix      flake.lock  images     native   packaging  scripts    src

fix/terminal..with-termios *8 ............................................................................ direnv nix impure 22:37:45
astrid@banana ~/Documents/caligula > 
```

`ls` does not have weird indentation anymore.