### PR TITLE
create script for running update tasks

### DIFF
--- a/scripts/update-deps.sh
+++ b/scripts/update-deps.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+branchname="update/$(date --rfc-3339=date)"
+echo "branch name: $branchname"
+
+set -euxo pipefail
+
+git checkout -b "$branchname"
+nix flake update
+git commit -a -m "nix flake update"
+
+nix develop --command cargo update
+git commit -a -m "cargo update"
+


### PR DESCRIPTION
## Test plan

```
% scripts/update-deps.sh
branch name: update/2024-11-15
+ git checkout -b update/2024-11-15
Switched to a new branch 'update/2024-11-15'
+ nix flake update
warning: updating lock file '/home/astrid/Documents/caligula/flake.lock':
• Updated input 'flake-utils':
    'github:numtide/flake-utils/b1d9ab70662946ef0850d488da1c9019f3a9752a?narHash=sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ%3D' (2024-03-11)
  → 'github:numtide/flake-utils/11707dc2f618dd54ca8739b309ec4fc024de578b?narHash=sha256-l0KFg5HjrsfsO/JpG%2Br7fRrqm12kzFHyUHqHCVpMMbI%3D' (2024-11-13)
• Updated input 'naersk':
    'github:nix-community/naersk/c5037590290c6c7dae2e42e7da1e247e54ed2d49?narHash=sha256-CO8MmVDmqZX2FovL75pu5BvwhW%2BVugc7Q6ze7Hj8heI%3D' (2024-04-19)
  → 'github:nix-community/naersk/3fb418eaf352498f6b6c30592e3beb63df42ef11?narHash=sha256-r/xppY958gmZ4oTfLiHN0ZGuQ%2BRSTijDblVgVLFi1mw%3D' (2024-07-23)
• Updated input 'naersk/nixpkgs':
    'github:NixOS/nixpkgs/3f316d2a50699a78afe5e77ca486ad553169061e?narHash=sha256-NQbegJb2ZZnAqp2EJhWwTf6DrZXSpA6xZCEq%2BRGV1r0%3D' (2024-05-22)
  → 'path:/nix/store/808lp63z6yiraikjpzcfk3xg1frpd2s0-source?lastModified=0&narHash=sha256-GKJjtPY%2BSXfLF/yTN7M2cAnQB6RERFKnQhD8UvPSf3M%3D' (1970-01-01)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/5710852ba686cc1fd0d3b8e22b3117d43ba374c2?narHash=sha256-8BO3B7e3BiyIDsaKA0tY8O88rClYRTjvAp66y%2BVBUeU%3D' (2024-05-21)
  → 'github:NixOS/nixpkgs/dc460ec76cbff0e66e269457d7b728432263166c?narHash=sha256-PbABj4tnbWFMfBp6OcUK5iGy1QY%2B/Z96ZcLpooIbuEI%3D' (2024-11-11)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/ee0db3aeebafeaada2b98d076de6d314b4c8682e?narHash=sha256-vdVzaGD5p%2BKG7XHepIeX5rUPmdzEcF2w6rhqfr0SNkI%3D' (2024-05-23)
  → 'github:oxalica/rust-overlay/db10c66da18e816030b884388545add8cf096647?narHash=sha256-6iuzRINXyPX4DfUQZIGafpJnzjFXjVRYMymB10/jFFY%3D' (2024-11-15)
• Removed input 'rust-overlay/flake-utils'
• Removed input 'rust-overlay/flake-utils/systems'
• Updated input 'rust-overlay/nixpkgs':
    'github:NixOS/nixpkgs/90f456026d284c22b3e3497be980b2e47d0b28ac?narHash=sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg%3D' (2024-01-29)
  → 'github:NixOS/nixpkgs/b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221?narHash=sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU%3D' (2024-10-10)
warning: Git tree '/home/astrid/Documents/caligula' is dirty
+ git commit -a -m 'nix flake update'
[update/2024-11-15 0c714cc] nix flake update
 1 file changed, 19 insertions(+), 55 deletions(-)
+ nix develop --command cargo update
evaluation warning: nixfmt was renamed to nixfmt-classic. The nixfmt attribute may be used for the new RFC 166-style formatter in the future, which is currently available as nixfmt-rfc-style
    Updating crates.io index
     Locking 111 packages to latest compatible versions
    Updating addr2line v0.21.0 -> v0.24.2
    Removing adler v1.0.2
      Adding adler2 v2.0.0
    Removing ahash v0.8.11
    Updating allocator-api2 v0.2.18 -> v0.2.20
    Updating anstream v0.6.14 -> v0.6.18
    Updating anstyle v1.0.7 -> v1.0.10
    Updating anstyle-parse v0.2.4 -> v0.2.6
    Updating anstyle-query v1.0.3 -> v1.1.2
    Updating anstyle-wincon v3.0.3 -> v3.0.6
    Updating anyhow v1.0.86 -> v1.0.93
    Updating autocfg v1.3.0 -> v1.4.0
    Updating backtrace v0.3.71 -> v0.3.74
    Updating bitflags v2.5.0 -> v2.6.0
      Adding bumpalo v3.16.0
    Updating bytes v1.6.0 -> v1.8.0
    Updating castaway v0.2.2 -> v0.2.3
    Updating cc v1.0.98 -> v1.2.1
    Updating clang-sys v1.7.0 -> v1.8.1
    Updating clap v4.5.4 -> v4.5.21
    Updating clap_builder v4.5.2 -> v4.5.21
    Updating clap_derive v4.5.4 -> v4.5.18
    Updating clap_lex v0.7.0 -> v0.7.3
    Updating colorchoice v1.0.1 -> v1.0.3
    Updating cpufeatures v0.2.12 -> v0.2.15
    Updating derive_more v0.99.17 -> v0.99.18 (latest: v1.0.0)
    Updating either v1.12.0 -> v1.13.0
      Adding equivalent v1.0.1
    Updating flate2 v1.0.30 -> v1.0.35
      Adding foldhash v0.1.3
    Updating futures v0.3.30 -> v0.3.31
    Updating futures-channel v0.3.30 -> v0.3.31
    Updating futures-core v0.3.30 -> v0.3.31
    Updating futures-executor v0.3.30 -> v0.3.31
    Updating futures-io v0.3.30 -> v0.3.31
    Updating futures-macro v0.3.30 -> v0.3.31
    Updating futures-sink v0.3.30 -> v0.3.31
    Updating futures-task v0.3.30 -> v0.3.31
    Updating futures-util v0.3.30 -> v0.3.31
    Updating gimli v0.28.1 -> v0.31.1
    Updating hashbrown v0.14.5 -> v0.15.1
    Removing heck v0.4.1
      Adding hermit-abi v0.4.0
    Updating indicatif v0.17.8 -> v0.17.9
    Removing instant v0.1.13
    Updating interprocess v2.1.1 -> v2.2.1
    Updating is-terminal v0.4.12 -> v0.4.13
    Updating is_terminal_polyfill v1.70.0 -> v1.70.1
      Adding itertools v0.13.0
      Adding js-sys v0.3.72
    Updating lazy_static v1.4.0 -> v1.5.0
    Updating libc v0.2.155 -> v0.2.162
    Updating libloading v0.8.3 -> v0.8.5
    Updating log v0.4.21 -> v0.4.22
    Updating lru v0.12.3 -> v0.12.5
    Updating memchr v2.7.2 -> v2.7.4
    Updating miniz_oxide v0.7.3 -> v0.8.0
      Adding mio v1.0.2
    Removing num_cpus v1.16.0
    Updating object v0.32.2 -> v0.36.5
    Updating once_cell v1.19.0 -> v1.20.2
    Updating parking_lot v0.12.2 -> v0.12.3
    Updating pin-project-lite v0.2.14 -> v0.2.15
    Updating pkg-config v0.3.30 -> v0.3.31
    Updating portable-atomic v1.6.0 -> v1.9.0
    Updating ppv-lite86 v0.2.17 -> v0.2.20
    Updating pretty_assertions v1.4.0 -> v1.4.1
    Updating proc-macro2 v1.0.83 -> v1.0.89
    Updating quote v1.0.36 -> v1.0.37
    Updating redox_syscall v0.5.1 -> v0.5.7
    Updating regex v1.10.4 -> v1.11.1
    Updating regex-automata v0.4.6 -> v0.4.9
    Updating regex-syntax v0.8.3 -> v0.8.5
    Updating rustc_version v0.4.0 -> v0.4.1
    Updating rustix v0.38.34 -> v0.38.40
    Updating rustversion v1.0.17 -> v1.0.18
    Updating serde v1.0.202 -> v1.0.215
    Updating serde_derive v1.0.202 -> v1.0.215
    Updating serde_json v1.0.117 -> v1.0.132
    Updating signal-hook-mio v0.2.3 -> v0.2.4
    Updating stability v0.2.0 -> v0.2.1
    Updating strum v0.26.2 -> v0.26.3
    Updating strum_macros v0.26.2 -> v0.26.4
    Updating syn v2.0.66 -> v2.0.87
    Updating terminal_size v0.3.0 -> v0.4.0
    Updating thiserror v1.0.61 -> v1.0.69 (latest: v2.0.3)
    Updating thiserror-impl v1.0.61 -> v1.0.69 (latest: v2.0.3)
    Updating tokio v1.37.0 -> v1.41.1
    Updating tokio-macros v2.2.0 -> v2.4.0
    Updating unicode-ident v1.0.12 -> v1.0.13
    Updating unicode-segmentation v1.11.0 -> v1.12.0
    Updating unicode-truncate v1.0.0 -> v1.1.0 (latest: v2.0.0)
    Removing unicode-width v0.1.12
      Adding unicode-width v0.1.14 (latest: v0.2.0)
      Adding unicode-width v0.2.0
    Updating utf8parse v0.2.1 -> v0.2.2
    Updating version_check v0.9.4 -> v0.9.5
      Adding wasm-bindgen v0.2.95
      Adding wasm-bindgen-backend v0.2.95
      Adding wasm-bindgen-macro v0.2.95
      Adding wasm-bindgen-macro-support v0.2.95
      Adding wasm-bindgen-shared v0.2.95
      Adding web-time v1.1.0
    Updating which v6.0.1 -> v6.0.3 (latest: v7.0.0)
      Adding windows-sys v0.59.0
    Updating windows-targets v0.52.5 -> v0.52.6
    Updating windows_aarch64_gnullvm v0.52.5 -> v0.52.6
    Updating windows_aarch64_msvc v0.52.5 -> v0.52.6
    Updating windows_i686_gnu v0.52.5 -> v0.52.6
    Updating windows_i686_gnullvm v0.52.5 -> v0.52.6
    Updating windows_i686_msvc v0.52.5 -> v0.52.6
    Updating windows_x86_64_gnu v0.52.5 -> v0.52.6
    Updating windows_x86_64_gnullvm v0.52.5 -> v0.52.6
    Updating windows_x86_64_msvc v0.52.5 -> v0.52.6
    Updating yansi v0.5.1 -> v1.0.1
    Updating zerocopy v0.7.34 -> v0.7.35 (latest: v0.8.10)
    Updating zerocopy-derive v0.7.34 -> v0.7.35 (latest: v0.8.10)
note: pass `--verbose` to see 38 unchanged dependencies behind latest
+ git commit -a -m 'cargo update'
[update/2024-11-15 ed8d1b0] cargo update
 1 file changed, 392 insertions(+), 286 deletions(-)
```