### PR TITLE
Only show "Removable" properties on disks

### DIFF
--- a/src/ui/simple_ui/ask_outfile.rs
+++ b/src/ui/simple_ui/ask_outfile.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 
 use crate::{
     compression::{CompressionArg, CompressionFormat, AVAILABLE_FORMATS},
-    device::{enumerate_devices, Removable, WriteTarget},
+    device::{self, enumerate_devices, Removable, WriteTarget},
     ui::{cli::BurnArgs, start::BeginParams},
 };
 
@@ -101,11 +101,19 @@ impl fmt::Display for ListOption {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ListOption::Device(dev) => {
-                write!(
-                    f,
-                    "{} | {} - {} ({}, removable: {})",
-                    dev.name, dev.model, dev.size, dev.target_type, dev.removable
-                )?;
+                if dev.target_type == device::Type::Disk {
+                    write!(
+                        f,
+                        "{} | {} - {} ({}, removable: {})",
+                        dev.name, dev.model, dev.size, dev.target_type, dev.removable
+                    )?;
+                } else {
+                    write!(
+                        f,
+                        "{} | {} - {} ({})",
+                        dev.name, dev.model, dev.size, dev.target_type
+                    )?;
+                }
             }
             ListOption::RetryWithShowAll(true) => {
                 write!(f, "<Show all disks, removable or not>")?;

--- a/src/ui/simple_ui/ask_outfile.rs
+++ b/src/ui/simple_ui/ask_outfile.rs
@@ -100,21 +100,18 @@ enum ListOption {
 impl fmt::Display for ListOption {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ListOption::Device(dev) => {
-                if dev.target_type == device::Type::Disk {
-                    write!(
-                        f,
-                        "{} | {} - {} ({}, removable: {})",
-                        dev.name, dev.model, dev.size, dev.target_type, dev.removable
-                    )?;
-                } else {
-                    write!(
-                        f,
-                        "{} | {} - {} ({})",
-                        dev.name, dev.model, dev.size, dev.target_type
-                    )?;
-                }
-            }
+            ListOption::Device(dev) => match dev.target_type {
+                device::Type::Disk => write!(
+                    f,
+                    "{} | {} - {} ({}, removable: {})",
+                    dev.name, dev.model, dev.size, dev.target_type, dev.removable
+                )?,
+                _ => write!(
+                    f,
+                    "{} | {} - {} ({})",
+                    dev.name, dev.model, dev.size, dev.target_type
+                )?,
+            },
             ListOption::RetryWithShowAll(true) => {
                 write!(f, "<Show all disks, removable or not>")?;
             }

--- a/src/ui/start.rs
+++ b/src/ui/start.rs
@@ -6,7 +6,7 @@ use tracing::debug;
 
 use crate::{
     compression::CompressionFormat,
-    device::WriteTarget,
+    device::{self, WriteTarget},
     logging::LogPaths,
     ui::{
         cli::{Interactive, UseSudo},
@@ -140,7 +140,10 @@ impl Display for BeginParams {
         writeln!(f, "  Block size: {}", self.target.block_size)?;
         writeln!(f, "  Type: {}", self.target.target_type)?;
         writeln!(f, "  Path: {}", self.target.devnode.to_string_lossy())?;
-        writeln!(f, "  Removable: {}", self.target.removable)?;
+
+        if self.target.target_type == device::Type::Disk {
+            writeln!(f, "  Removable: {}", self.target.removable)?;
+        }
 
         Ok(())
     }


### PR DESCRIPTION
- Only display `Removable` properties on disks, as it is unnecessary to show them for partitions and files.