### PR TITLE
Fixed ci tests for run0

### DIFF
--- a/checks/autoescalate/default.nix
+++ b/checks/autoescalate/default.nix
@@ -23,6 +23,8 @@ nixosTest {
         else if escalationTool == "run0" then {
           security.sudo.enable = mkForce false;
 
+          security.polkit.enable = true;
+
           # see https://warlord0blog.wordpress.com/2024/07/30/passwordless-run0/
           security.polkit.extraConfig = ''
             polkit.addRule(function(action, subject) {

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -18,8 +18,8 @@ in with lib;
       pkgs.callPackage ./autoescalate { escalationTool = "doas"; };
     autoescalate-sudo =
       pkgs.callPackage ./autoescalate { escalationTool = "sudo"; };
-    # autoescalate-run0 =
-    #   pkgs.callPackage ./autoescalate { escalationTool = "run0"; };
+     autoescalate-run0 =
+       pkgs.callPackage ./autoescalate { escalationTool = "run0"; };
   } //
 
   # blocksize alignment tests

--- a/src/escalation/unix.rs
+++ b/src/escalation/unix.rs
@@ -27,7 +27,9 @@ pub struct Command<'a> {
 }
 
 impl EscalationMethod {
-    const ALL: [EscalationMethod; 4] = [Self::Sudo, Self::Doas, Self::Su, Self::Run0];
+    // Order is relevant here. Since this array is enumerated in `EscalationMethod::detect()`
+    // The first esalation found tool will be used
+    const ALL: [EscalationMethod; 4] = [Self::Sudo, Self::Doas, Self::Run0, Self::Su];
 
     pub fn detect() -> Result<Self, Error> {
         for m in Self::ALL {


### PR DESCRIPTION
It bugged me that the tests weren't working. So I spent a few hours today debugging this.

There were two problems with the test.

1. polkit needs to be enabled explicitly https://wiki.nixos.org/wiki/Polkit#Enable_polkit
2. `su` escalation needs to be the last option to be choosen for `run0` to be selected as a valid escalation tool.

The problem with `su` being chosen was damn near invisible. The only error message I got was: `machine # su: must be run from a terminal` which didn't help matters since only the subtest (`subtest: should succeed when run as non-root wheel user`) failed.