### PR TITLE
Drop dependency on tracing-valuable

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["--cfg", "tracing_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracing-unwrap",
- "valuable",
  "which 6.0.1",
  "xz2",
 ]
@@ -1802,20 +1801,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-dependencies = [
- "valuable-derive",
-]
-
-[[package]]
-name = "valuable-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d44690c645190cfce32f91a1582281654b2338c6073fa250b0949fd25c55b32"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,11 +47,9 @@ tracing = { version = "0.1.40", features = [
     "async-await",
     "log",
     "release_max_level_debug",
-    "valuable",
 ] }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "fmt"] }
 tracing-unwrap = "1.0.1"
-valuable = { version = "0.1.0", features = ["derive"] }
 which = "6.0.1"
 xz2 = { version = "0.1.7", features = ["static"] }
 

--- a/src/childproc_common.rs
+++ b/src/childproc_common.rs
@@ -4,7 +4,6 @@ use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 use tracing::{error, info};
 use tracing_unwrap::ResultExt;
-use valuable::Valuable;
 
 use crate::logging::init_logging_child;
 
@@ -18,7 +17,7 @@ use crate::logging::init_logging_child;
 /// - Get the child-specific config from arg 3
 ///
 /// This returns the socket path and the child-specific config.
-pub fn child_init<C: DeserializeOwned + Debug + Valuable>() -> (String, C) {
+pub fn child_init<C: DeserializeOwned + Debug>() -> (String, C) {
     let cli_args: Vec<String> = env::args().collect();
 
     // We will set up logging first because if any part of this godforsaken
@@ -31,11 +30,7 @@ pub fn child_init<C: DeserializeOwned + Debug + Valuable>() -> (String, C) {
 
     let socket_path = &cli_args[2];
     let args = serde_json::from_str::<C>(&cli_args[3]).unwrap_or_log();
-    info!(
-        ?socket_path,
-        args = args.as_value(),
-        "We are in child process mode"
-    );
+    info!(?socket_path, ?args, "We are in child process mode");
 
     (socket_path.clone(), args)
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use serde::{Deserialize, Serialize};
-use valuable::Valuable;
 
 macro_rules! generate {
     {
@@ -47,7 +46,7 @@ macro_rules! generate {
             }
         }
 
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Valuable)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
         pub enum CompressionFormat {
             Identity,
             $(

--- a/src/device.rs
+++ b/src/device.rs
@@ -7,7 +7,6 @@ use std::{
 
 use bytesize::ByteSize;
 use serde::{Deserialize, Serialize};
-use valuable::Valuable;
 
 #[cfg(target_os = "linux")]
 pub fn enumerate_devices() -> impl Iterator<Item = WriteTarget> {
@@ -307,7 +306,7 @@ impl Display for Removable {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Valuable)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
 pub enum Type {
     File,
     Disk,

--- a/src/escalated_daemon/ipc.rs
+++ b/src/escalated_daemon/ipc.rs
@@ -1,14 +1,13 @@
 use serde::{Deserialize, Serialize};
-use valuable::Valuable;
 
 use crate::writer_process::ipc::WriterProcessConfig;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Valuable)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EscalatedDaemonInitConfig {
     // Okay, there's nothing here right now, but there might be someday!
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Valuable)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SpawnWriter {
     pub log_file: String,
     pub init_config: WriterProcessConfig,

--- a/src/escalated_daemon/mod.rs
+++ b/src/escalated_daemon/mod.rs
@@ -18,7 +18,6 @@ use interprocess::local_socket::{tokio::prelude::*, GenericFilePath};
 use tokio::io::{AsyncBufRead, BufReader};
 use tracing::{error, info, info_span, Instrument};
 use tracing_unwrap::ResultExt;
-use valuable::Valuable;
 
 use crate::{
     childproc_common::child_init,
@@ -51,7 +50,7 @@ pub async fn main() {
 async fn event_loop(socket: &str, mut stream: impl AsyncBufRead + Unpin) -> anyhow::Result<()> {
     loop {
         let msg = read_msg_async::<SpawnWriter>(&mut stream).await?;
-        info!(msg = msg.as_value(), "Received SpawnWriter request");
+        info!(?msg, "Received SpawnWriter request");
 
         let command =
             make_writer_spawn_command(socket.into(), msg.log_file.into(), &msg.init_config);

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -3,7 +3,6 @@ use digest::Digest;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::io::Read;
-use valuable::Valuable;
 
 macro_rules! generate {
     {$(
@@ -17,7 +16,7 @@ macro_rules! generate {
             })*
         ]
     )*} => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Valuable)]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
         pub enum HashAlg {
             $($(
                 $enum_arm,

--- a/src/run_mode.rs
+++ b/src/run_mode.rs
@@ -2,7 +2,6 @@ use std::{borrow::Cow, fmt::Debug};
 
 use process_path::get_executable_path;
 use serde::Serialize;
-use valuable::Valuable;
 
 use crate::{
     escalated_daemon::ipc::EscalatedDaemonInitConfig, escalation::Command,
@@ -67,7 +66,7 @@ impl RunMode {
 }
 
 /// Build a [Command] that, when run, spawns a process with a specific configuration.
-pub fn make_spawn_command<'a, C: Serialize + Debug + Valuable>(
+pub fn make_spawn_command<'a, C: Serialize + Debug>(
     socket: Cow<'a, str>,
     log_path: Cow<'a, str>,
     run_mode: RunMode,

--- a/src/ui/herder/herder.rs
+++ b/src/ui/herder/herder.rs
@@ -12,7 +12,6 @@ use crate::{
 use anyhow::Context;
 use interprocess::local_socket::tokio::prelude::*;
 use tracing::{debug, trace};
-use valuable::Valuable;
 
 use crate::escalation::run_escalate;
 use crate::writer_process::ipc::{StatusMessage, WriterProcessConfig};
@@ -109,10 +108,7 @@ impl Herder {
 
         trace!("Reading results from child");
         let first_msg = read_msg_async::<StatusMessage>(&mut handle.rx).await?;
-        debug!(
-            first_msg = first_msg.as_value(),
-            "Read raw result from child"
-        );
+        debug!(?first_msg, "Read raw result from child");
 
         let initial_info = match first_msg {
             StatusMessage::InitSuccess(i) => Ok(i),

--- a/src/writer_process/ipc.rs
+++ b/src/writer_process/ipc.rs
@@ -2,12 +2,10 @@ use std::{fmt::Display, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use valuable::Valuable;
-
 use crate::compression::CompressionFormat;
 use crate::device::Type;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Valuable)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WriterProcessConfig {
     pub dest: PathBuf,
     pub src: PathBuf,
@@ -17,7 +15,7 @@ pub struct WriterProcessConfig {
     pub block_size: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Valuable)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StatusMessage {
     InitSuccess(InitialInfo),
     TotalBytes {
@@ -37,12 +35,12 @@ pub enum StatusMessage {
     Error(ErrorType),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Valuable)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InitialInfo {
     pub input_file_bytes: u64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Valuable)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ErrorType {
     EndOfOutput,
     PermissionDenied,


### PR DESCRIPTION
This is used a whopping grand total of 3 times and causes #141, and makes it so that I need that annoying .cargo/config.toml thing. Goodbye!

This will close #141.

## Test plan

CI that shit