### PR TITLE
Ensure lockfiles are up-to-date in CI scripts

### DIFF
--- a/nix/cross-helpers.nix
+++ b/nix/cross-helpers.nix
@@ -32,10 +32,12 @@ in rec {
   supportedSystems = if hostInfo.kernel.name == "linux" then [
     "aarch64-linux"
     "x86_64-linux"
-  ] else if host == "x86_64-darwin" then [
-    # "aarch64-darwin" # Temporarily broken. TODO: fix
-    "x86_64-darwin"
-  ] else if host == "aarch64-darwin" then
+  ] else if host == "x86_64-darwin" then
+    [
+      # "aarch64-darwin" # Temporarily broken. TODO: fix
+      "x86_64-darwin"
+    ]
+  else if host == "aarch64-darwin" then
     [ "aarch64-darwin" ]
   else
     throw "unsupported host system ${host}";
@@ -85,8 +87,9 @@ in rec {
 
       crossParams = if host == target then {
         cc = pkgs.stdenv.cc;
-        extraBuildEnv = { 
-          RUST_SRC_PATH = "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
+        extraBuildEnv = {
+          RUST_SRC_PATH =
+            "${pkgs.rust.packages.stable.rustPlatform.rustLibSrc}";
         };
       } else rec {
         cc = pkgsCross.stdenv.cc;
@@ -107,6 +110,7 @@ in rec {
           doCheck = host == target;
           propagatedBuildInputs = [ crossParams.cc ];
           inherit buildInputs;
+          cargoBuildOptions = args: args ++ [ "--locked" ];
           CARGO_BUILD_TARGET = buildCfg.rustTarget;
         } // crossParams.extraBuildEnv);
 

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -20,4 +20,4 @@ sed -i "$sedcmd" "$cargotoml"
 
 git add "$cargotoml"
 git commit -m "bump version to v$version"
-
+cargo lock


### PR DESCRIPTION
Issue brought up in #166. 

## Test plan

### Setup

Applying the following patch to the repo:

```patch
diff --git a/Cargo.lock b/Cargo.lock
index 5e2defc..e3dd73c 100644
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "caligula"
-version = "0.4.8"
+version = "0.4.7"
 dependencies = [
  "aligned-vec",
  "anyhow",
```

### Tests

`nix build` fails:

```
% nix build .

warning: Git tree '/home/astrid/Documents/caligula' is dirty
error: builder for '/nix/store/0815nh9jrvmwsf10f3g0mlbs0imjfhi5-caligula-deps-0.4.8.drv' failed with exit code 101;
       last 24 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/kr5d2wxl6mlw1qzry4a4jxhd5pqh3sbi-dummy-src
       > source root is dummy-src
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > [naersk] cargo_version (read): 1.78.0 (54d8815d0 2024-03-26)
       > [naersk] cargo_message_format (set): json-diagnostic-rendered-ansi
       > [naersk] cargo_release: --release
       > [naersk] cargo_options:
       > [naersk] cargo_build_options: $cargo_release -j "$NIX_BUILD_CORES" --message-format=$cargo_message_format --locked
       > [naersk] cargo_test_options: $cargo_release -j "$NIX_BUILD_CORES"
       > [naersk] RUST_TEST_THREADS: 8
       > [naersk] cargo_bins_jq_filter: .
       > [naersk] cargo_build_output_json (created): /build/tmp.YXNXoFkJYf
       > [naersk] RUSTFLAGS:
       > [naersk] CARGO_BUILD_RUSTFLAGS:
       > [naersk] CARGO_BUILD_RUSTFLAGS (updated):  --remap-path-prefix /nix/store/a1svbvgg0l33m5cagi1xc9ymwc2cf8gh-crates-io-dependencies=/sources --remap-path-prefix /nix/store/60s16s4138d4q0shg766nb2hzrqymd6i-git-dependencies=/sources
       > Running phase: buildPhase
       > cargo build $cargo_release -j "$NIX_BUILD_CORES" --message-format=$cargo_message_format --locked
       > warning: both `/build/dummy-src/.cargo-home/config` and `/build/dummy-src/.cargo-home/config.toml` exist. Using `/build/dummy-src/.cargo-home/config`
       > error: the lock file /build/dummy-src/Cargo.lock needs to be updated but --locked was passed to prevent this
       > If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
       > [naersk] cargo returned with exit code 101, exiting
       For full logs, run 'nix log /nix/store/0815nh9jrvmwsf10f3g0mlbs0imjfhi5-caligula-deps-0.4.8.drv'.
error: 1 dependencies of derivation '/nix/store/inqmw48i4kja4r2n70xdg8knv1ps1d3y-caligula-0.4.8.drv' failed to build
```