### PR TITLE
Replace PathBuf with Path when ownership or mutability is not needed

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -40,7 +40,7 @@ pub fn enumerate_devices() -> impl Iterator<Item = WriteTarget> {
             let bsdname = OsStr::from_bytes(CStr::from_ptr(d.bsdname).to_bytes());
             let mut rawdevname = OsString::from("r");
             rawdevname.push(bsdname);
-            let devnode: PathBuf = PathBuf::from("/dev").join(rawdevname);
+            let devnode = Path::new("/dev").join(rawdevname);
             let bsdname = bsdname.to_string_lossy().into();
             free(d.bsdname as *mut c_void);
 
@@ -149,12 +149,12 @@ impl WriteTarget {
             }
         }
 
-        let devnode = PathBuf::from("/dev").join(name);
+        let devnode = Path::new("/dev").join(name);
         if !devnode.exists() {
             return Err(DeviceParseError::NotFound);
         }
 
-        let sysnode = PathBuf::from("/sys/class/block").join(name);
+        let sysnode = Path::new("/sys/class/block").join(name);
 
         let removable = match read_sys_file(sysnode.join("removable"))?
             .as_ref()
@@ -195,10 +195,10 @@ impl WriteTarget {
         })
     }
 
-    fn from_normal_file(path: PathBuf) -> Result<Self, DeviceParseError> {
+    fn from_normal_file(path: &Path) -> Result<Self, DeviceParseError> {
         Ok(WriteTarget {
             name: path.to_string_lossy().into(),
-            devnode: path,
+            devnode: path.into(),
             size: TargetSize(None),
             model: Model(None),
             removable: Removable::Unknown,
@@ -238,7 +238,7 @@ impl TryFrom<&Path> for WriteTarget {
             }
         }
 
-        Self::from_normal_file(value.to_owned())
+        Self::from_normal_file(value)
     }
 }
 

--- a/src/ui/main.rs
+++ b/src/ui/main.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, path::PathBuf, sync::Arc};
+use std::{fs::File, path::Path, sync::Arc};
 
 use crate::{
     logging::{init_logging_parent, LogPaths},
@@ -33,7 +33,7 @@ pub async fn main() {
     };
 
     debug!("Starting primary process");
-    match inner_main(state_dir, log_paths).await {
+    match inner_main(&state_dir, log_paths).await {
         Ok(_) => (),
         Err(e) => handle_toplevel_error(e),
     }
@@ -52,7 +52,7 @@ fn handle_toplevel_error(err: anyhow::Error) {
     }
 }
 
-async fn inner_main(state_dir: PathBuf, log_paths: LogPaths) -> anyhow::Result<()> {
+async fn inner_main(state_dir: &Path, log_paths: LogPaths) -> anyhow::Result<()> {
     let args = Args::parse();
     let Command::Burn(args) = args.command;
 


### PR DESCRIPTION
## Summary

- When ownership or mutability is not needed, prefer `Path` to `PathBuf`.

<!-- Please include:

- relevant motivation and context.
- the related issue, if applicable
- a summary of the changes
- a list of dependency PRs required for this change -->

## Type of change

<!-- Check boxes as applicable. Please add more options if you feel that they are relevant. -->

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] This change requires a documentation update

## Test plan

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. If you feel your change is minimal enough or already covered by automated tests, you can simply put "CI". -->

todo
