### PR TITLE
Add flag `--hash-file`

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Options:
   -o <OUT>                         Where to write the output. If not supplied, we will search for possible disks and ask you for where you want to burn
   -z, --compression <COMPRESSION>  What compression format the input file is in [default: ask] [possible values: ask, auto, none, gz, bz2, xz]
   -s, --hash <HASH>                The hash of the input file. For more information, see long help (--help) [default: ask]
+      --hash-file <HASH_FILE>      Where to look for the hash of the input file
       --hash-of <HASH_OF>          Is the hash calculated from the raw file, or the compressed file? [possible values: raw, compressed]
       --show-all-disks             If provided, we will show all disks, removable or not
       --interactive <INTERACTIVE>  If we should run in interactive mode or not [default: auto] [possible values: auto, always, never]
@@ -46,7 +47,7 @@ Options:
 There are a couple of ways to install Caligula.
 
 - **Binary release:** You can download pre-built binaries from [the latest Github release](https://github.com/ifd3f/caligula/releases/latest).
-- **Arch Linux:** 
+- **Arch Linux:**
   - [Official repository](https://archlinux.org/packages/extra/x86_64/caligula): `pacman -S caligula`
   - [caligula-bin on the AUR](https://aur.archlinux.org/packages/caligula-bin): We also automatically publish binaries with every release.
   - [caligula-git on the AUR](https://aur.archlinux.org/packages/caligula-git): Build from latest commit on `main` branch

--- a/src/ui/cli.rs
+++ b/src/ui/cli.rs
@@ -69,6 +69,10 @@ pub struct BurnArgs {
     )]
     pub hash: HashArg,
 
+    /// Where to look for the hash of the input file.
+    #[arg(long, value_parser = parse_path_exists)]
+    pub hash_file: Option<PathBuf>,
+
     /// Is the hash calculated from the raw file, or the compressed file?
     #[arg(long)]
     pub hash_of: Option<HashOf>,


### PR DESCRIPTION
## Summary

This PR implements a new CLI option, `--hash-file`. I described my motivation for it in issue #183:

> When I want Caligula to use a hash from a file it doesn't recognize, I need to give it a `--hash` argument. This involves either manually copying the hash and pasting it in the shell or somewhat complex command substitution like `--hash "$(awk '$2 ~ /^foo/ { print $1 }' foo.iso.sha256)"`.

I wasn't sure what error behavior was appropriate when a user-supplied hash file doesn't contain a valid hash for the input filename. Should it be a fatal error? I decided to imitate the behavior for standard files like `SHA256SUMS` because that's what the program already does. If we don't find the hash in a custom hash file, we move on to asking.

The PR refactors existing functions. It renames `find_hash` in `hashfile.rs` to `find_hash_in_standard_files` for symmetry with the new function `find_hash_in_user_file`. In `ask_hash.rs`, it splits `ask_alg` out of `ask_hash_once`.

I didn't find tests for `find_hash`, so I don't add any for `find_hash_in_user_file`. They'd probably have to be [rexpect](https://github.com/rust-cli/rexpect) tests.

Resolves #183. Probably obsoletes #181.

<!-- Please include:

- relevant motivation and context.
- the related issue, if applicable
- a summary of the changes
- a list of dependency PRs required for this change -->

## Type of change

<!-- Check boxes as applicable. Please add more options if you feel that they are relevant. -->

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] This change requires a documentation update

## Test plan

CI.