### PR TITLE
Set flatten_help = true

### DIFF
--- a/src/ui/cli.rs
+++ b/src/ui/cli.rs
@@ -9,9 +9,9 @@ use crate::{
     hash::{parse_hash_input, HashAlg},
 };
 
-/// A safe, user-friendly disk imager.
+/// A lightweight, user-friendly disk imaging tool
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about, long_about = None, flatten_help = true)]
 #[command(propagate_version = true)]
 pub struct Args {
     #[command(subcommand)]


### PR DESCRIPTION
## Summary

Running `caligula` on its own doesn't show all the flags. As pointed out by #189 and various videos reviewing it, it's very confusing because we only have one subcommand right now.

```
% caligula
A lightweight, user-friendly disk imaging tool

Usage: caligula <COMMAND>

Commands:
  burn  A lightweight, user-friendly disk imaging tool
  help  Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

This change fixes that problem.

Closes #189.

## Type of change

<!-- Check boxes as applicable. Please add more options if you feel that they are relevant. -->

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] This change requires a documentation update

## Test plan

```
% cargo run # with zero arguments!
   Compiling caligula v0.4.9 (/home/astrid/Documents/caligula)

<snip warnings>

warning: `caligula` (bin "caligula") generated 5 warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.97s
     Running `target/debug/caligula`
A lightweight, user-friendly disk imaging tool

Usage: caligula burn [OPTIONS] <INPUT>
       caligula help [COMMAND]...

Options:
  -h, --help     Print help
  -V, --version  Print version

caligula burn:
A lightweight, user-friendly disk imaging tool
  -o <OUT>                         Where to write the output. If not supplied, we will search for possible disks and ask you for where you want to burn
  -z, --compression <COMPRESSION>  What compression format the input file is in [default: ask] [possible values: ask, auto, none, gz, bz2, xz, lz4, zst]
  -s, --hash <HASH>                The hash of the input file. For more information, see long help (--help) [default: ask]
      --hash-file <HASH_FILE>      Where to look for the hash of the input file
      --hash-of <HASH_OF>          Is the hash calculated from the raw file, or the compressed file? [possible values: raw, compressed]
      --show-all-disks             If provided, we will show all disks, removable or not
      --interactive <INTERACTIVE>  If we should run in interactive mode or not [default: auto] [possible values: auto, always, never]
  -f, --force                      If supplied, we will not ask for confirmation before destroying your disk
      --root <ROOT>                If we don't have permissions on the output file, should we try to become root? [default: ask] [possible values: ask, always, never]
  -h, --help                       Print help (see more with '--help')
  -V, --version                    Print version
  <INPUT>                          Input file to burn

caligula help:
Print this message or the help of the given subcommand(s)
  [COMMAND]...  Print help for the subcommand(s)
```