### PR TITLE
Improve help output a bit more

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ caligula
 A lightweight, user-friendly disk imaging tool
 
 Usage: caligula
-       caligula burn [OPTIONS] <INPUT>
+       caligula burn [OPTIONS] <IMAGE>
        caligula help [COMMAND]...
 
 Options:
@@ -22,6 +22,7 @@ Options:
 
 caligula burn:
 A lightweight, user-friendly disk imaging tool
+  <IMAGE>                          Input image to burn
   -o <OUT>                         Where to write the output. If not supplied, we will search for possible disks and ask you for where you want to burn
   -z, --compression <COMPRESSION>  What compression format the input file is in [default: ask] [possible values: ask, auto, none, gz, bz2, xz, lz4, zst]
   -s, --hash <HASH>                The hash of the input file. For more information, see long help (--help) [default: ask]
@@ -33,7 +34,6 @@ A lightweight, user-friendly disk imaging tool
       --root <ROOT>                If we don't have permissions on the output file, should we try to become root? [default: ask] [possible values: ask, always, never]
   -h, --help                       Print help (see more with '--help')
   -V, --version                    Print version
-  <INPUT>                          Input file to burn
 
 caligula help:
 Print this message or the help of the given subcommand(s)

--- a/src/ui/cli.rs
+++ b/src/ui/cli.rs
@@ -27,13 +27,13 @@ pub enum Command {
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct BurnArgs {
-    /// Input file to burn.
-    #[arg(value_parser = parse_path_exists)]
-    pub input: PathBuf,
+    /// Input image to burn.
+    #[arg(value_parser = parse_path_exists, display_order = 0)]
+    pub image: PathBuf,
 
     /// Where to write the output. If not supplied, we will search for possible
     /// disks and ask you for where you want to burn.
-    #[arg(short)]
+    #[arg(short, display_order = 1)] // needs display_order = 1 or else it will go above image
     pub out: Option<PathBuf>,
 
     /// What compression format the input file is in.

--- a/src/ui/simple_ui/ask_hash.rs
+++ b/src/ui/simple_ui/ask_hash.rs
@@ -21,7 +21,7 @@ use crate::{
 pub fn ask_hash(args: &BurnArgs, cf: CompressionFormat) -> anyhow::Result<Option<FileHashInfo>> {
     let hash_params = match (&args.hash, &args.hash_file) {
         (_, Some(hash_file)) => {
-            let Some((algs, _, expected_hash)) = find_hash_in_user_file(&args.input, hash_file)
+            let Some((algs, _, expected_hash)) = find_hash_in_user_file(&args.image, hash_file)
             else {
                 eprintln!(
                     "Could not parse {} as a valid hash file!",
@@ -42,7 +42,7 @@ pub fn ask_hash(args: &BurnArgs, cf: CompressionFormat) -> anyhow::Result<Option
         }
         (HashArg::Skip, _) => None,
         (HashArg::Ask, _) => {
-            match find_hash_in_standard_files(&args.input) {
+            match find_hash_in_standard_files(&args.image) {
                 Some((algs, expected_hashfile, expected_hash))
                     if Confirm::new(&format!(
                         "Detected hash file {expected_hashfile} in the directory. Do you want to use it?"
@@ -72,7 +72,7 @@ pub fn ask_hash(args: &BurnArgs, cf: CompressionFormat) -> anyhow::Result<Option
         return Ok(None);
     };
 
-    let hash_result = do_hashing(&args.input, &params)?;
+    let hash_result = do_hashing(&args.image, &params)?;
 
     if hash_result.file_hash == params.expected_hash {
         eprintln!("Disk image verified successfully!");

--- a/src/ui/simple_ui/ask_outfile.rs
+++ b/src/ui/simple_ui/ask_outfile.rs
@@ -13,13 +13,13 @@ use crate::{
 pub fn ask_compression(args: &BurnArgs) -> anyhow::Result<CompressionFormat> {
     let cf = match args.compression {
         CompressionArg::Auto | CompressionArg::Ask => {
-            CompressionFormat::detect_from_path(&args.input)
+            CompressionFormat::detect_from_path(&args.image)
         }
         other => other.associated_format(),
     };
 
     if let Some(cf) = cf {
-        eprintln!("Input file: {}", args.input.to_string_lossy());
+        eprintln!("Input file: {}", args.image.to_string_lossy());
         eprintln!("Detected compression format: {}", cf);
 
         if args.force || args.compression != CompressionArg::Ask {
@@ -34,7 +34,7 @@ pub fn ask_compression(args: &BurnArgs) -> anyhow::Result<CompressionFormat> {
 
     eprintln!(
         "Couldn't detect compression format for {}",
-        args.input.to_string_lossy()
+        args.image.to_string_lossy()
     );
     if args.force {
         eprintln!("Since --force was provided, assuming it's uncompressed!");

--- a/src/ui/simple_ui/mod.rs
+++ b/src/ui/simple_ui/mod.rs
@@ -34,7 +34,7 @@ pub fn do_setup_wizard(args: &BurnArgs) -> Result<Option<BeginParams>, anyhow::E
         Some(f) => WriteTarget::try_from(f.as_ref())?,
         None => ask_outfile(args)?,
     };
-    let begin_params = BeginParams::new(args.input.clone(), compression, target)?;
+    let begin_params = BeginParams::new(args.image.clone(), compression, target)?;
     if !confirm_write(args, &begin_params)? {
         eprintln!("Aborting.");
         return Ok(None);


### PR DESCRIPTION
## Summary

1. says "IMAGE" like #189 suggests
2. "IMAGE" is now at the very very top of the help dialog

## Type of change

<!-- Check boxes as applicable. Please add more options if you feel that they are relevant. -->

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] This change requires a documentation update
- [x] This change contains modifications to the `--help` output
    - [x] I ran `scripts/regenerate_readme.py` from the root directory to ensure it has the latest sample output

## Test plan

CI
