### PR TITLE
Silent failure when passing a directory as input

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -84,5 +84,7 @@ fn init_tracing_subscriber(write_path: impl AsRef<Path>) {
                 .with_default_directive(FILE_LOG_LEVEL.into())
                 .from_env_lossy(),
         )
+        .with_file(true)
+        .with_line_number(true)
         .init();
 }

--- a/src/ui/cli.rs
+++ b/src/ui/cli.rs
@@ -28,7 +28,7 @@ pub enum Command {
 #[command(author, version, about, long_about = None)]
 pub struct BurnArgs {
     /// Input image to burn.
-    #[arg(value_parser = parse_path_exists, display_order = 0)]
+    #[arg(value_parser = parse_image_path, display_order = 0)]
     pub image: PathBuf,
 
     /// Where to write the output. If not supplied, we will search for possible
@@ -135,6 +135,17 @@ fn parse_path_exists(p: &str) -> Result<PathBuf, String> {
         return Err("path does not exist".to_string());
     }
     Ok(path)
+}
+
+fn parse_path_is_file(path: PathBuf) -> Result<PathBuf, String> {
+    if !path.is_file() {
+        return Err("path is not a file or symlink to a file".to_string());
+    }
+    Ok(path)
+}
+
+fn parse_image_path(p: &str) -> Result<PathBuf, String> {
+    parse_path_exists(p).and_then(parse_path_is_file)
 }
 
 fn parse_hash_arg(h: &str) -> Result<HashArg, String> {


### PR DESCRIPTION
## Summary

<!-- Please include:

- relevant motivation and context.
- the related issue, if applicable
- a summary of the changes
- a list of dependency PRs required for this change -->

Addresses and closes #208.

- Add requirement to `image` argument to be a file (or a symbolic link to a file), preventing accidentally passing directories
- Add file name and line number to log entries

## Type of change

<!-- Check boxes as applicable. Please add more options if you feel that they are relevant. -->

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] This change requires a documentation update
- [ ] This change contains modifications to the `--help` output
    - [ ] I ran `scripts/regenerate_readme.py` from the root directory to ensure it has the latest sample output

## Test plan

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. If you feel your change is minimal enough or already covered by automated tests, you can simply put "CI". -->

Try to `burn` a directory, and it should fail with the following error

```sh
$ caligula burn --force --compression none --hash skip -o /dev/sda /tmp/caligula-668102-1766420269461/
error: invalid value '/tmp/caligula-668102-1766420269461/' for '<IMAGE>': path is not a file or symlink to a file

For more information, try '--help'.
```

Log files should contain the file and line number where it was generated

```log
$ cat /tmp/caligula-1027724-1766426069683/log/main.log 
2025-12-22T17:54:29.683412Z  INFO caligula::tty: src/tty.rs:14: attempting to store terminal state before program started
2025-12-22T17:54:29.683424Z DEBUG caligula::ui::main: src/ui/main.rs:35: Starting primary process
...
```