### PR TITLE
remove serde_json from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,7 +260,6 @@ dependencies = [
  "rstest",
  "ruzstd",
  "serde",
- "serde_json",
  "sha1",
  "sha2",
  "shell-words",
@@ -1413,19 +1412,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,9 +2188,3 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ process_path = "0.1.4"
 ratatui = "0.26.3"
 ruzstd = "0.6.0"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
 sha1 = "0.10.6"
 sha2 = "0.10.9"
 shell-words = "1.1.0"


### PR DESCRIPTION
## Summary

<!-- Please include:

- relevant motivation and context.
- the related issue, if applicable
- a summary of the changes
- a list of dependency PRs required for this change -->

`serde_json` is unused in codebase, we can remove it from `Cargo.toml`.

## Type of change

<!-- Check boxes as applicable. Please add more options if you feel that they are relevant. -->

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] This change requires a documentation update
- [ ] This change contains modifications to the `--help` output
    - [ ] I ran `scripts/regenerate_readme.py` from the root directory to ensure it has the latest sample output

## Test plan

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. If you feel your change is minimal enough or already covered by automated tests, you can simply put "CI". -->

I ran `cargo build` on my `x86_64_unknown_gnu` machine, and searched for "json" using `rg json` with no matches.
