### PR TITLE
use less features from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,9 +323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -409,7 +407,6 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -695,15 +692,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuzzy-matcher"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
-dependencies = [
- "thread_local",
-]
-
-[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -804,7 +792,6 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width 0.2.2",
  "web-time",
 ]
 
@@ -817,12 +804,11 @@ dependencies = [
  "bitflags 2.11.0",
  "crossterm 0.25.0",
  "dyn-clone",
- "fuzzy-matcher",
  "fxhash",
  "newline-converter",
  "once_cell",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -946,7 +932,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
- "twox-hash 2.1.2",
+ "twox-hash",
 ]
 
 [[package]]
@@ -1230,7 +1216,7 @@ dependencies = [
  "strum",
  "unicode-segmentation",
  "unicode-truncate",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1361,7 +1347,6 @@ checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
 dependencies = [
  "byteorder",
  "derive_more",
- "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -1518,16 +1503,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "stability"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,10 +1649,8 @@ dependencies = [
  "bytes",
  "libc",
  "mio 1.2.0",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1710,7 +1683,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -1787,16 +1759,6 @@ dependencies = [
 
 [[package]]
 name = "twox-hash"
-version = "1.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
-dependencies = [
- "cfg-if",
- "static_assertions",
-]
-
-[[package]]
-name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
@@ -1827,7 +1789,7 @@ checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1835,12 +1797,6 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,37 +17,35 @@ bincode = "1.3.3"
 byteorder = "1.5.0"
 bytesize = "1.3.3"
 bzip2 = { version = "0.6.1", features = ["static"] }
-chrono = "0.4.42"
+chrono = { version = "0.4.42", default-features = false, features = ["clock"] }
 clap = { version = "4.5.49", features = ["derive", "cargo", "wrap_help"] }
 crossterm = { version = "0.27.0", features = ["event-stream"] }
 derive_more = "0.99.20"
 digest = "0.10.7"
 flate2 = "1.1.4"
 format-bytes = "0.3.0"
-futures = "0.3.31"
+futures = { version = "0.3.31", default-features = false, features = ["std"] }
 futures-io = "0.3.31"
-indicatif = "0.17.11"
-inquire = "0.7.5"
+indicatif = { version = "0.17.11", default-features = false }
+inquire = { version = "0.7.5", default-features = false, features = ["crossterm"] }
 is-terminal = "0.4.16"
 itertools = "0.12.1"
 libc = "0.2.177"
-lz4_flex = "0.11.6"
-md-5 = "0.10.6"
+lz4_flex = { version = "0.11.6", default-features = false, features = ["frame"] }
+md-5 = { version = "0.10.6", default-features = false }
 process_path = "0.1.4"
-ratatui = "0.26.3"
-ruzstd = "0.6.0"
+ratatui = { version = "0.26.3", default-features = false, features = ["crossterm"] }
+ruzstd = { version = "0.6.0", default-features = false, features = ["std"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 sha1 = "0.10.6"
 sha2 = "0.10.9"
 shell-words = "1.1.0"
 thiserror = "1.0.69"
-tokio = { version = "1.48.0", features = ["full"] }
+tokio = { version = "1.48.0", features = ["rt-multi-thread", "process", "io-util", "io-std", "macros", "fs"] }
 tokio-stream = "0.1.18"
-tracing = { version = "0.1.41", features = [
-    "async-await",
-    "log",
-    "release_max_level_debug",
+tracing = { version = "0.1.41", default-features = false, features = [
+    "std",
 ] }
 tracing-panic = "0.1.2"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }


### PR DESCRIPTION
## Summary

<!-- Please include:

- relevant motivation and context.
- the related issue, if applicable
- a summary of the changes
- a list of dependency PRs required for this change -->

I noticed a lot of dependencies were pulling in default features. I tried disabling default features for every one of them and ensured it still worked.

This cuts down dependencies from 233 to 227, but a cold debug build (on my machine) takes the same amount of time.

## Type of change

<!-- Check boxes as applicable. Please add more options if you feel that they are relevant. -->

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] This change requires a documentation update
- [ ] This change contains modifications to the `--help` output
    - [ ] I ran `scripts/regenerate_readme.py` from the root directory to ensure it has the latest sample output

## Test plan

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. If you feel your change is minimal enough or already covered by automated tests, you can simply put "CI". -->

I did `cargo build` on my `x86_64-unknown-linux-gnu` machine.

I also did a burn, the TUI and CLI seem intact.
