### PR TITLE
add `cargo-machete` CI job to identify unused dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
       - name: Run lint script
         run: nix run .#lint-script
 
+  cargo-machete:
+    name: Check for unused dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: bnjbvr/cargo-machete@v0.9.2
+
   ci-x86_64-linux:
     uses: ./.github/workflows/ci-unix.yml
     with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ is-terminal = "0.4.16"
 itertools = "0.12.1"
 libc = "0.2.177"
 lz4_flex = { version = "0.11.6", default-features = false, features = ["frame"] }
-md-5 = { version = "0.10.6", default-features = false }
+md5 = { package = "md-5", version = "0.10.6", default-features = false }
 process_path = "0.1.4"
 ratatui = { version = "0.26.3", default-features = false, features = ["crossterm"] }
 ruzstd = { version = "0.6.0", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ is-terminal = "0.4.16"
 itertools = "0.12.1"
 libc = "0.2.177"
 lz4_flex = { version = "0.11.6", default-features = false, features = ["frame"] }
+# aliased to appease cargo-machete because the crate's namespace is md5 rather than md_5
 md5 = { package = "md-5", version = "0.10.6", default-features = false }
 process_path = "0.1.4"
 ratatui = { version = "0.26.3", default-features = false, features = ["crossterm"] }


### PR DESCRIPTION
Following up on #227.

`cargo-machete` incorrectly identified `md-5` dependency as unused. I think it has to do with the module in Rust code being `md5::Md5` instead of `md-5`.

Aliasing the crate in `Cargo.toml` seems to solve the issue. Do you think that's acceptable?