### PR TITLE
Make stub methods on the Orchestrator (and clean up write_verify a bit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "bincode",
  "bindgen",
  "byteorder",
+ "bytes",
  "bytesize",
  "bzip2",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ base16 = "0.2.1"
 base64 = "0.22.1"
 bincode = "1.3.3"
 byteorder = "1.5.0"
+bytes = "1.11.1"
 bytesize = "1.3.3"
 bzip2 = { version = "0.6.1", features = ["static"] }
 chrono = { version = "0.4.42", default-features = false, features = ["clock"] }

--- a/src/escalation/unix.rs
+++ b/src/escalation/unix.rs
@@ -8,6 +8,7 @@ use super::EscalationError;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, derive_more::Display)]
 pub enum EscalationMethod {
+    // TODO: add a GUI sudo method for Linuxes
     #[display(fmt = "sudo")]
     Sudo,
     #[display(fmt = "doas")]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -16,7 +16,11 @@ macro_rules! generate {
             })*
         ]
     )*} => {
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+        /// A hashing algorithm supported by Caligula.
+        ///
+        /// [`Ord`] is implemented in order by security. Lower-security algorithms are
+        /// less than higher-security algorithms.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
         pub enum HashAlg {
             $($(
                 $enum_arm,

--- a/src/orchestrator/analyze_input.rs
+++ b/src/orchestrator/analyze_input.rs
@@ -1,0 +1,71 @@
+#![expect(unused, reason = "Stub interface created for later use.")]
+
+use std::path::PathBuf;
+
+use bytes::Bytes;
+
+use crate::{compression::CompressionFormat, hash::HashAlg, util::candidate::Candidates};
+
+/// Result of analyzing an input file for its properties.
+pub struct InputAnalysis {
+    pub compression: Candidates<CompressionCandidate>,
+    pub hash_file: Candidates<HashFile>,
+}
+
+/// Newtype wrapper around [`CompressionFormat`] that supports [`Ord`].
+///
+/// All compression algorithms are considered equal for [`Candidates`] purposes.
+#[derive(Debug)]
+pub struct CompressionCandidate(pub CompressionFormat);
+
+impl PartialEq for CompressionCandidate {
+    fn eq(&self, other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for CompressionCandidate {}
+
+impl PartialOrd for CompressionCandidate {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+impl Ord for CompressionCandidate {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        std::cmp::Ordering::Equal
+    }
+}
+
+/// Hash value derived from a file.
+///
+/// In case of tie, the more secure algorithms win.
+#[derive(Debug)]
+pub struct HashFile {
+    pub alg: HashAlg,
+    /// The hash we expect.
+    pub expected_hash: Bytes,
+    /// Name of the file
+    pub file: PathBuf,
+}
+
+impl PartialEq for HashFile {
+    fn eq(&self, other: &Self) -> bool {
+        self.alg.eq(&other.alg)
+    }
+}
+
+impl Eq for HashFile {}
+
+impl PartialOrd for HashFile {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(&other))
+    }
+}
+
+impl Ord for HashFile {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.alg.cmp(&other.alg)
+    }
+}

--- a/src/orchestrator/analyze_input.rs
+++ b/src/orchestrator/analyze_input.rs
@@ -28,7 +28,7 @@ impl Eq for CompressionCandidate {}
 
 impl PartialOrd for CompressionCandidate {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 
@@ -60,7 +60,7 @@ impl Eq for HashFile {}
 
 impl PartialOrd for HashFile {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/orchestrator/disks.rs
+++ b/src/orchestrator/disks.rs
@@ -4,7 +4,10 @@ use std::{collections::VecDeque, iter, sync::Mutex};
 
 use crate::device::{DeviceParseError, WriteTarget};
 
+/// Handle for viewing the list of disks we've found.
 pub struct DiskList {
+    loading: bool,
+
     /// List of disks we've discovered.
     disks: Vec<WriteTarget>,
 
@@ -13,6 +16,11 @@ pub struct DiskList {
 }
 
 impl DiskList {
+    /// Returns true if we're still loading the initial list of disks.
+    pub fn loading(&self) -> bool {
+        self.loading
+    }
+
     /// List of disks we've discovered.
     pub fn disks(&self) -> &[WriteTarget] {
         &self.disks

--- a/src/orchestrator/disks.rs
+++ b/src/orchestrator/disks.rs
@@ -1,0 +1,28 @@
+#![expect(unused, reason = "Stub interface created for later use.")]
+
+use std::{collections::VecDeque, iter, sync::Mutex};
+
+use crate::device::{DeviceParseError, WriteTarget};
+
+pub struct DiskList {
+    /// List of disks we've discovered.
+    disks: Vec<WriteTarget>,
+
+    /// Errors encountered while listing disks.
+    errors: Mutex<VecDeque<DeviceParseError>>,
+}
+
+impl DiskList {
+    /// List of disks we've discovered.
+    pub fn disks(&self) -> &[WriteTarget] {
+        &self.disks
+    }
+
+    /// All errors encountered while listing disks, in order as encountered.
+    ///
+    /// Accessing this iterator will pop errors off this disk list.
+    pub fn errors(&self) -> impl Iterator<Item = DeviceParseError> + '_ {
+        let mut guard = self.errors.lock().unwrap();
+        iter::from_fn(move || guard.pop_front())
+    }
+}

--- a/src/orchestrator/hash.rs
+++ b/src/orchestrator/hash.rs
@@ -1,7 +1,8 @@
 #![expect(unused, reason = "Stub interface created for later use.")]
 
-use bytes::Bytes;
 use std::{path::PathBuf, time::Instant};
+
+use bytes::Bytes;
 
 use crate::{
     byteseries::ByteSeries, compression::CompressionFormat, hash::HashAlg,

--- a/src/orchestrator/hash.rs
+++ b/src/orchestrator/hash.rs
@@ -1,0 +1,65 @@
+#![expect(unused, reason = "Stub interface created for later use.")]
+
+use bytes::Bytes;
+use std::{path::PathBuf, time::Instant};
+
+use crate::{
+    byteseries::ByteSeries, compression::CompressionFormat, hash::HashAlg,
+    orchestrator::watch::Watch,
+};
+
+/// Parameters for starting a new hashing operation.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct StartHashParams {
+    /// File to use
+    pub file: PathBuf,
+
+    /// Algorithm to run
+    pub alg: HashAlg,
+
+    /// How to decompress the file before performing hash (if at all).
+    pub compression: CompressionFormat,
+}
+
+/// Result from hash starting.
+pub struct HashStarted {
+    /// Handle for watching the state updates of this hasher.
+    pub state: Watch<HashingState>,
+}
+
+/// Active, point-in-time state of a hashing operation.
+pub struct HashingState {
+    /// Read speed history.
+    read_bytes_history: ByteSeries,
+    /// How big the file is
+    file_size_bytes: u64,
+    /// Result of the operation. If [`None`], the operation is not yet finished.
+    result: Option<std::io::Result<Bytes>>,
+}
+
+impl HashingState {
+    pub fn new(now: Instant, file_size_bytes: u64) -> Self {
+        Self {
+            read_bytes_history: ByteSeries::new(now),
+            file_size_bytes,
+            result: None,
+        }
+    }
+
+    /// Whether or not this operation is finished.
+    pub fn is_finished(&self) -> bool {
+        self.result.is_some()
+    }
+
+    pub fn read_bytes_history(&self) -> &ByteSeries {
+        &self.read_bytes_history
+    }
+
+    pub fn file_size_bytes(&self) -> u64 {
+        self.file_size_bytes
+    }
+
+    pub fn result(&self) -> Option<&std::io::Result<Bytes>> {
+        self.result.as_ref()
+    }
+}

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -43,27 +43,29 @@ mod write_verify;
 /// new UI developments.
 pub trait Orchestrator: Sync + Send + 'static {
     /// Analyze an input file to guess how we should handle it.
-    /// 
-    /// Returns the results of the analysis, or an error if the file could not be read.
-    /// This method is fault-tolerant, so the only errors that can cause this operation to fail
-    /// are I/O errors.
-    /// 
-    /// The intended workflow is that you call it once, to fill up your UI's wizard with data,
-    /// and then ask the user for more information if there's anything that's not certain.
+    ///
+    /// Returns the results of the analysis, or an error if the file could not
+    /// be read. This method is fault-tolerant, so the only errors that can
+    /// cause this operation to fail are I/O errors.
+    ///
+    /// The intended workflow is that you call it once, to fill up your UI's
+    /// wizard with data, and then ask the user for more information if
+    /// there's anything that's not certain.
     #[expect(unused, reason = "Stub interface created for later use.")]
     async fn analyze_input(&self, input: PathBuf) -> std::io::Result<InputAnalysis>;
 
     /// Get a handle for watching the list of disks available. This may update
     /// as disks are added and removed to the system.
-    /// 
-    /// Although this returns a handle immediately, the initial results may take a while to load.
+    ///
+    /// Although this returns a handle immediately, the initial results may take
+    /// a while to load.
     #[expect(unused, reason = "Stub interface created for later use.")]
     fn watch_disks(&self) -> watch::Watch<DiskList>;
 
     /// Read a file and calculate its hash in a background thread.
-    /// 
-    /// Returns when the file is opened and the thread is running, with a handle to watch its progress,
-    /// or an error if the file could not be opened.
+    ///
+    /// Returns when the file is opened and the thread is running, with a handle
+    /// to watch its progress, or an error if the file could not be opened.
     #[expect(unused, reason = "Stub interface created for later use.")]
     async fn start_hash(&self, params: StartHashParams) -> std::io::Result<HashStarted>;
 

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -1,14 +1,22 @@
 //! Exposes the [`Orchestrator`], which is a facade that orchestrates all
 //! "high-level" work and tracks the state of worker tasks.
 
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 pub use self::{
+    disks::DiskList,
+    hash::{HashError, HashStarted, StartHashParams},
     herder_facade::{DaemonError, StartWriterError},
     write_verify::{WriteVerifyParams, WriteVerifyStarted, WriterState},
 };
-use crate::{escalation::EscalationMethod, herder_api::write_verify::*, runtime::RemoteSpawn};
+use crate::{
+    escalation::EscalationMethod, herder_api::write_verify::*,
+    orchestrator::analyze_input::InputAnalysis, runtime::RemoteSpawn,
+};
 
+mod analyze_input;
+mod disks;
+mod hash;
 mod herder_facade;
 mod real;
 pub mod watch;
@@ -34,13 +42,26 @@ mod write_verify;
 /// error types, but in general, the overall shape of this API can be used for
 /// new UI developments.
 pub trait Orchestrator: Sync + Send + 'static {
-    /// Start a write + verify workflow.
+    /// Analyze an input file to guess how we should handle it.
+    #[expect(unused, reason = "Stub interface created for later use.")]
+    async fn analyze_input(&self, input: PathBuf) -> std::io::Result<InputAnalysis>;
+
+    /// Get a handle for watching the list of disks available. This may update
+    /// as disks are added and removed.
+    #[expect(unused, reason = "Stub interface created for later use.")]
+    async fn watch_disks(&self) -> watch::Watch<DiskList>;
+
+    /// Start a hashing workflow in the background.
+    #[expect(unused, reason = "Stub interface created for later use.")]
+    async fn start_hash(&self, params: StartHashParams) -> std::io::Result<HashStarted>;
+
+    /// Start a write + verify workflow in the background.
     ///
     /// Returns when we get an initial success message from the task group, or
     /// there was a failure.
     async fn start_write_verify(
         &self,
-        begin_params: WriteVerifyParams,
+        params: WriteVerifyParams,
     ) -> Result<WriteVerifyStarted, StartWriterError<WriteVerifyEvent>>;
 
     /// Attempt to spawn a child process as root using the provided escalation
@@ -59,7 +80,7 @@ pub trait Orchestrator: Sync + Send + 'static {
     async fn escalate(&self, method: Option<EscalationMethod>) -> Result<(), DaemonError>;
 
     /// Returns whether or not we have a child process running as root.
-    #[expect(dead_code)]
+    #[expect(unused, reason = "Stub interface created for later use.")]
     fn is_escalated(&self) -> bool;
 }
 
@@ -78,10 +99,10 @@ pub trait OrchestratorExt: Orchestrator {
     fn start_write_verify_blocking(
         self: Arc<Self>,
         spawn: impl RemoteSpawn,
-        begin_params: WriteVerifyParams,
+        params: WriteVerifyParams,
     ) -> Result<WriteVerifyStarted, StartWriterError<WriteVerifyEvent>> {
         spawn
-            .spawn(move || async move { self.start_write_verify(begin_params).await })
+            .spawn(move || async move { self.start_write_verify(params).await })
             .blocking_recv()
             .expect("remote task dropped!")
     }

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -43,15 +43,27 @@ mod write_verify;
 /// new UI developments.
 pub trait Orchestrator: Sync + Send + 'static {
     /// Analyze an input file to guess how we should handle it.
+    /// 
+    /// Returns the results of the analysis, or an error if the file could not be read.
+    /// This method is fault-tolerant, so the only errors that can cause this operation to fail
+    /// are I/O errors.
+    /// 
+    /// The intended workflow is that you call it once, to fill up your UI's wizard with data,
+    /// and then ask the user for more information if there's anything that's not certain.
     #[expect(unused, reason = "Stub interface created for later use.")]
     async fn analyze_input(&self, input: PathBuf) -> std::io::Result<InputAnalysis>;
 
     /// Get a handle for watching the list of disks available. This may update
-    /// as disks are added and removed.
+    /// as disks are added and removed to the system.
+    /// 
+    /// Although this returns a handle immediately, the initial results may take a while to load.
     #[expect(unused, reason = "Stub interface created for later use.")]
-    async fn watch_disks(&self) -> watch::Watch<DiskList>;
+    fn watch_disks(&self) -> watch::Watch<DiskList>;
 
-    /// Start a hashing workflow in the background.
+    /// Read a file and calculate its hash in a background thread.
+    /// 
+    /// Returns when the file is opened and the thread is running, with a handle to watch its progress,
+    /// or an error if the file could not be opened.
     #[expect(unused, reason = "Stub interface created for later use.")]
     async fn start_hash(&self, params: StartHashParams) -> std::io::Result<HashStarted>;
 

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -5,9 +5,9 @@ use std::{path::PathBuf, sync::Arc};
 
 pub use self::{
     disks::DiskList,
-    hash::{HashError, HashStarted, StartHashParams},
+    hash::{HashStarted, StartHashParams},
     herder_facade::{DaemonError, StartWriterError},
-    write_verify::{WriteVerifyParams, WriteVerifyStarted, WriterState},
+    write_verify::{WriteVerifyParams, WriteVerifyStarted, WriterVerifyState},
 };
 use crate::{
     escalation::EscalationMethod, herder_api::write_verify::*,

--- a/src/orchestrator/real.rs
+++ b/src/orchestrator/real.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::{path::PathBuf, time::Instant};
 
 use futures::StreamExt;
 
@@ -6,7 +6,12 @@ use super::herder_facade::{DaemonError, HerderFacade, StartWriterError};
 use crate::{
     escalation::EscalationMethod,
     herder_api::write_verify::WriteVerifyEvent,
-    orchestrator::{Orchestrator, WriteVerifyParams, WriteVerifyStarted, WriterState},
+    orchestrator::{
+        DiskList, Orchestrator, WriteVerifyParams, WriteVerifyStarted, WriterState,
+        analyze_input::InputAnalysis,
+        hash::{HashError, HashStarted, StartHashParams},
+        watch::Watch,
+    },
 };
 
 /// Actual orchestrator implementation used by Caligula.
@@ -77,6 +82,29 @@ impl<H: HerderFacade + Send + 'static> Orchestrator for OrchestratorImpl<H> {
     }
 
     fn is_escalated(&self) -> bool {
-        todo!()
+        // TODO: this is badly implemented but it's good enough for writing new UIs against.
+        // It will be improved when we get rid of herder facade.
+        let Ok(lock) = self.inner.try_lock() else {
+            return false;
+        };
+        lock.escalation.is_some()
+    }
+
+    async fn start_hash(&self, _params: StartHashParams) -> std::io::Result<HashStarted> {
+        unimplemented!(
+            "Until this is implemented, for testing purposes, you may replace this with test values."
+        )
+    }
+
+    async fn watch_disks(&self) -> Watch<DiskList> {
+        unimplemented!(
+            "Until this is implemented, for testing purposes, you may replace this with test values."
+        )
+    }
+
+    async fn analyze_input(&self, _input: PathBuf) -> std::io::Result<InputAnalysis> {
+        unimplemented!(
+            "Until this is implemented, for testing purposes, you may replace this with test values."
+        )
     }
 }

--- a/src/orchestrator/real.rs
+++ b/src/orchestrator/real.rs
@@ -96,7 +96,7 @@ impl<H: HerderFacade + Send + 'static> Orchestrator for OrchestratorImpl<H> {
         )
     }
 
-    async fn watch_disks(&self) -> Watch<DiskList> {
+    fn watch_disks(&self) -> Watch<DiskList> {
         unimplemented!(
             "Until this is implemented, for testing purposes, you may replace this with test values."
         )

--- a/src/orchestrator/real.rs
+++ b/src/orchestrator/real.rs
@@ -82,8 +82,8 @@ impl<H: HerderFacade + Send + 'static> Orchestrator for OrchestratorImpl<H> {
     }
 
     fn is_escalated(&self) -> bool {
-        // TODO: this is badly implemented but it's good enough for writing new UIs against.
-        // It will be improved when we get rid of herder facade.
+        // TODO: this is badly implemented but it's good enough for writing new UIs
+        // against. It will be improved when we get rid of herder facade.
         let Ok(lock) = self.inner.try_lock() else {
             return false;
         };

--- a/src/orchestrator/real.rs
+++ b/src/orchestrator/real.rs
@@ -7,9 +7,9 @@ use crate::{
     escalation::EscalationMethod,
     herder_api::write_verify::WriteVerifyEvent,
     orchestrator::{
-        DiskList, Orchestrator, WriteVerifyParams, WriteVerifyStarted, WriterState,
+        DiskList, Orchestrator, WriteVerifyParams, WriteVerifyStarted, WriterVerifyState,
         analyze_input::InputAnalysis,
-        hash::{HashError, HashStarted, StartHashParams},
+        hash::{HashStarted, StartHashParams},
         watch::Watch,
     },
 };
@@ -52,7 +52,7 @@ impl<H: HerderFacade + Send + 'static> Orchestrator for OrchestratorImpl<H> {
         drop(inner);
 
         // create state reduction task
-        let (tx_state, rx_state) = tokio::sync::watch::channel(WriterState::initial(
+        let (tx_state, rx_state) = tokio::sync::watch::channel(WriterVerifyState::initial(
             Instant::now(),
             !params.compression.is_identity(),
             handle.initial_info.input_file_bytes,

--- a/src/orchestrator/write_verify.rs
+++ b/src/orchestrator/write_verify.rs
@@ -25,7 +25,7 @@ pub struct WriteVerifyParams {
 pub struct WriteVerifyStarted {
     #[expect(dead_code)]
     pub start: WriteVerifyStart,
-    pub state: Watch<WriterState>,
+    pub state: Watch<WriterVerifyState>,
 }
 
 impl WriteVerifyParams {
@@ -55,10 +55,10 @@ impl WriteVerifyParams {
     }
 }
 
-/// A state machine for tracking the state of the writer, based on received
+/// A state machine for tracking the state of the writer and verifier, based on received
 /// messages.
 #[derive(Debug, Clone, PartialEq)]
-pub enum WriterState {
+pub enum WriterVerifyState {
     Writing(Writing),
     Verifying {
         write_hist: ByteSeries,
@@ -67,17 +67,17 @@ pub enum WriterState {
     },
     Finished {
         finish_time: Instant,
-        error: Option<WriteVerifyError>,
+        result: Result<(), WriteVerifyError>,
         write_hist: ByteSeries,
         verify_hist: Option<ByteSeries>,
         total_write_bytes: u64,
     },
 }
 
-impl WriterState {
+impl WriterVerifyState {
     #[tracing::instrument]
     pub fn initial(now: Instant, is_input_compressed: bool, input_file_bytes: u64) -> Self {
-        WriterState::Writing(Writing::new(now, is_input_compressed, input_file_bytes))
+        WriterVerifyState::Writing(Writing::new(now, is_input_compressed, input_file_bytes))
     }
 
     #[tracing::instrument(skip_all, fields(msg), level = "debug")]
@@ -91,21 +91,21 @@ impl WriterState {
             Some(WriteVerifyEvent::FinishedWriting { verifying }) => {
                 info!("Received finished writing notification");
                 match self {
-                    WriterState::Writing(st) => st.into_finished(now, verifying),
+                    WriterVerifyState::Writing(st) => st.into_finished(now, verifying),
                     c => c,
                 }
             }
             Some(WriteVerifyEvent::Error(reason)) => {
                 info!("Received error notification");
-                self.into_finished(now, Some(reason))
+                self.into_finished(now, Err(reason))
             }
             Some(WriteVerifyEvent::Success) => {
                 info!("Received success notification");
-                self.into_finished(now, None)
+                self.into_finished(now, Ok(()))
             }
             None => {
                 info!("Messages terminated unexpectedly");
-                self.into_finished(now, Some(WriteVerifyError::UnexpectedTermination))
+                self.into_finished(now, Err(WriteVerifyError::UnexpectedTermination))
             }
             other => panic!(
                 "Received unexpected child status {:#?}\nCurrent state: {:#?}",
@@ -132,36 +132,36 @@ impl WriterState {
 
     fn on_total_bytes(&mut self, now: Instant, src: u64, dest: u64) {
         match self {
-            WriterState::Writing(st) => {
+            WriterVerifyState::Writing(st) => {
                 st.read_hist.push(now, src);
                 st.write_hist.push(now, dest);
             }
-            WriterState::Verifying { verify_hist, .. } => verify_hist.push(now, dest),
-            WriterState::Finished { .. } => {}
+            WriterVerifyState::Verifying { verify_hist, .. } => verify_hist.push(now, dest),
+            WriterVerifyState::Finished { .. } => {}
         };
     }
 
-    fn into_finished(self, now: Instant, error: Option<WriteVerifyError>) -> WriterState {
+    fn into_finished(self, now: Instant, error: Result<(), WriteVerifyError>) -> WriterVerifyState {
         match self {
-            WriterState::Writing(st) => {
+            WriterVerifyState::Writing(st) => {
                 let total_write_bytes = st.write_hist.bytes_encountered();
-                WriterState::Finished {
+                WriterVerifyState::Finished {
                     finish_time: now,
-                    error,
+                    result: error,
                     write_hist: st.write_hist,
                     verify_hist: None,
                     total_write_bytes,
                 }
             }
-            WriterState::Verifying {
+            WriterVerifyState::Verifying {
                 write_hist,
                 verify_hist,
                 ..
             } => {
                 let total_write_bytes = write_hist.bytes_encountered();
-                WriterState::Finished {
+                WriterVerifyState::Finished {
                     finish_time: now,
-                    error,
+                    result: error,
                     write_hist,
                     verify_hist: Some(verify_hist),
                     total_write_bytes,
@@ -172,17 +172,17 @@ impl WriterState {
     }
 
     pub fn is_finished(&self) -> bool {
-        matches!(self, WriterState::Finished { .. })
+        matches!(self, WriterVerifyState::Finished { .. })
     }
 }
 
-impl Default for WriterState {
+impl Default for WriterVerifyState {
     /// Suitable value to put into the cell when [`std::mem::take()`] is called.
     fn default() -> Self {
         let now = Instant::now();
         Self::Finished {
             finish_time: now,
-            error: Some(WriteVerifyError::Panicked),
+            result: Err(WriteVerifyError::Panicked),
             write_hist: ByteSeries::new(now),
             verify_hist: None,
             total_write_bytes: 0,
@@ -190,6 +190,7 @@ impl Default for WriterState {
     }
 }
 
+/// Data tracked during active writing.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Writing {
     pub write_hist: ByteSeries,
@@ -226,22 +227,22 @@ impl Writing {
         }
     }
 
-    fn into_finished(self, time: Instant, verifying: bool) -> WriterState {
+    fn into_finished(self, time: Instant, verifying: bool) -> WriterVerifyState {
         let total_write_bytes = self.write_hist.bytes_encountered();
 
         if verifying {
             info!(verifying, "Transition to verifying");
 
-            WriterState::Verifying {
+            WriterVerifyState::Verifying {
                 write_hist: self.write_hist,
                 verify_hist: ByteSeries::new(time),
                 total_write_bytes,
             }
         } else {
             info!(verifying, "Transition to finished");
-            WriterState::Finished {
+            WriterVerifyState::Finished {
                 finish_time: time,
-                error: None,
+                result: Ok(()),
                 write_hist: self.write_hist,
                 verify_hist: None,
                 total_write_bytes,
@@ -254,13 +255,13 @@ impl Writing {
 mod tests {
     use std::time::{Duration, Instant};
 
-    use super::WriterState;
+    use super::WriterVerifyState;
     use crate::{byteseries::ByteSeries, herder_api::write_verify::*};
 
     #[test]
     fn accept_total_bytes_messages() {
         let t0 = Instant::now();
-        let s = WriterState::initial(t0, false, 80)
+        let s = WriterVerifyState::initial(t0, false, 80)
             .on_status(
                 t0 + Duration::from_secs(1),
                 Some(WriteVerifyEvent::TotalBytes { src: 20, dest: 10 }),
@@ -275,7 +276,7 @@ mod tests {
             );
 
         let s = match s {
-            WriterState::Writing(s) => s,
+            WriterVerifyState::Writing(s) => s,
             s => panic!("unexpected {:#?}", s),
         };
         assert_eq!(s.read_hist.last_datapoint(), (3.0, 60));
@@ -285,13 +286,13 @@ mod tests {
     #[test]
     fn writing_value_for_uncompressed_ratio() {
         let t0 = Instant::now();
-        let s = WriterState::initial(t0, false, 400).on_status(
+        let s = WriterVerifyState::initial(t0, false, 400).on_status(
             t0 + Duration::from_secs(1),
             Some(WriteVerifyEvent::TotalBytes { src: 15, dest: 40 }),
         );
 
         let s = match s {
-            WriterState::Writing(s) => s,
+            WriterVerifyState::Writing(s) => s,
             s => panic!("unexpected {:#?}", s),
         };
         assert_eq!(s.approximate_ratio(), 0.1);
@@ -300,7 +301,7 @@ mod tests {
     #[test]
     fn writing_value_for_compressed_ratio() {
         let t0 = Instant::now();
-        let s = WriterState::initial(t0, true, 80).on_status(
+        let s = WriterVerifyState::initial(t0, true, 80).on_status(
             t0 + Duration::from_secs(1),
             Some(WriteVerifyEvent::TotalBytes {
                 src: 20,
@@ -309,7 +310,7 @@ mod tests {
         );
 
         let s = match s {
-            WriterState::Writing(s) => s,
+            WriterVerifyState::Writing(s) => s,
             s => panic!("unexpected {s:#?}"),
         };
         assert_eq!(s.approximate_ratio(), 0.25);
@@ -318,7 +319,7 @@ mod tests {
     #[test]
     fn sudden_terminate_in_writing_state_sets_error() {
         let t0 = Instant::now();
-        let s = WriterState::initial(t0, true, 80)
+        let s = WriterVerifyState::initial(t0, true, 80)
             .on_status(
                 t0 + Duration::from_secs(1),
                 Some(WriteVerifyEvent::TotalBytes { src: 20, dest: 20 }),
@@ -326,11 +327,11 @@ mod tests {
             .on_status(t0 + Duration::from_secs(2), None);
 
         match s {
-            WriterState::Finished {
-                finish_time, error, ..
+            WriterVerifyState::Finished {
+                finish_time, result: error, ..
             } => {
                 assert_eq!(finish_time - t0, Duration::from_secs(2));
-                assert_eq!(error, Some(WriteVerifyError::UnexpectedTermination));
+                assert_eq!(error, Err(WriteVerifyError::UnexpectedTermination));
             }
             s => panic!("Unexpected {s:#?}"),
         }
@@ -340,9 +341,9 @@ mod tests {
     fn terminate_during_finished_is_idempotent() {
         let t0 = Instant::now();
         let finish_time = t0 + Duration::from_secs(10);
-        let s0 = WriterState::Finished {
+        let s0 = WriterVerifyState::Finished {
             finish_time,
-            error: None,
+            result: Ok(()),
             write_hist: ByteSeries::new(t0),
             verify_hist: None,
             total_write_bytes: 12345678,
@@ -358,9 +359,9 @@ mod tests {
     fn finished_during_finished_is_idempotent() {
         let t0 = Instant::now();
         let finish_time = t0 + Duration::from_secs(10);
-        let s0 = WriterState::Finished {
+        let s0 = WriterVerifyState::Finished {
             finish_time,
-            error: None,
+            result: Ok(()),
             write_hist: ByteSeries::new(t0),
             verify_hist: None,
             total_write_bytes: 12345678,

--- a/src/orchestrator/write_verify.rs
+++ b/src/orchestrator/write_verify.rs
@@ -55,8 +55,8 @@ impl WriteVerifyParams {
     }
 }
 
-/// A state machine for tracking the state of the writer and verifier, based on received
-/// messages.
+/// A state machine for tracking the state of the writer and verifier, based on
+/// received messages.
 #[derive(Debug, Clone, PartialEq)]
 pub enum WriterVerifyState {
     Writing(Writing),
@@ -328,7 +328,9 @@ mod tests {
 
         match s {
             WriterVerifyState::Finished {
-                finish_time, result: error, ..
+                finish_time,
+                result: error,
+                ..
             } => {
                 assert_eq!(finish_time - t0, Duration::from_secs(2));
                 assert_eq!(error, Err(WriteVerifyError::UnexpectedTermination));

--- a/src/ui/fancy_ui/display.rs
+++ b/src/ui/fancy_ui/display.rs
@@ -10,7 +10,7 @@ use super::{
     state::State,
     widgets::{SpeedChart, WriterProgressBar, WritingInfoTable},
 };
-use crate::{logging::LogPaths, orchestrator::WriterState};
+use crate::{logging::LogPaths, orchestrator::WriterVerifyState};
 
 struct ComputedLayout {
     progress: Rect,
@@ -68,7 +68,7 @@ fn centered_rect(r: Rect, w: u16, h: u16) -> Rect {
 /// Draw the TUI.
 pub fn draw(
     state: &mut State,
-    child: &WriterState,
+    child: &WriterVerifyState,
     terminal: &mut Terminal<impl ratatui::backend::Backend>,
     log_paths: &LogPaths,
 ) -> std::io::Result<()> {
@@ -77,12 +77,12 @@ pub fn draw(
     let progress_bar = WriterProgressBar::from_writer(child);
 
     let final_time = match child {
-        WriterState::Finished { finish_time, .. } => *finish_time,
+        WriterVerifyState::Finished { finish_time, .. } => *finish_time,
         _ => Instant::now(),
     };
 
     let error = match &child {
-        WriterState::Finished { error, .. } => error.as_ref(),
+        WriterVerifyState::Finished { result: error, .. } => error.as_ref().err(),
         _ => None,
     };
 

--- a/src/ui/fancy_ui/mod.rs
+++ b/src/ui/fancy_ui/mod.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc;
 use self::state::UIEvent;
 use crate::{
     logging::LogPaths,
-    orchestrator::{WriteVerifyParams, WriterState, watch::Watch},
+    orchestrator::{WriteVerifyParams, WriterVerifyState, watch::Watch},
     runtime::RemoteSpawn,
     ui::fancy_ui::{display::draw, state::State},
 };
@@ -26,7 +26,7 @@ where
 {
     pub terminal: &'a mut Terminal<B>,
     pub begin: &'a WriteVerifyParams,
-    pub child_state: Watch<WriterState>,
+    pub child_state: Watch<WriterVerifyState>,
     pub terminal_events: T,
     pub log_paths: &'a LogPaths,
 }
@@ -88,7 +88,7 @@ fn draw_loop(
     terminal: &mut Terminal<impl Backend>,
     mut state: State,
     events: impl IntoIterator<Item = UIEvent>,
-    child: Watch<WriterState>,
+    child: Watch<WriterVerifyState>,
     log_paths: &LogPaths,
 ) {
     for ev in events {

--- a/src/ui/fancy_ui/state.rs
+++ b/src/ui/fancy_ui/state.rs
@@ -4,7 +4,7 @@ use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use tracing::info;
 
 use super::widgets::{QuitModal, QuitModalResult, SpeedChartState};
-use crate::orchestrator::{WriteVerifyParams, WriterState};
+use crate::orchestrator::{WriteVerifyParams, WriterVerifyState};
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum UIEvent {
@@ -34,7 +34,7 @@ impl State {
     ///
     /// Returns [`Self`], or [`None`] to signal completion.
     #[tracing::instrument(skip_all, level = "debug", fields(ev))]
-    pub fn on_event(self, child: &WriterState, ev: UIEvent) -> Option<Self> {
+    pub fn on_event(self, child: &WriterVerifyState, ev: UIEvent) -> Option<Self> {
         match ev {
             UIEvent::SleepTimeout => Some(self),
             UIEvent::RecvTermEvent(e) => self.on_term_event(child, e),
@@ -44,7 +44,7 @@ impl State {
     #[tracing::instrument(skip_all, level = "debug", fields(ev))]
     fn on_term_event(
         self,
-        child: &WriterState,
+        child: &WriterVerifyState,
         ev: Result<Event, (String, std::io::ErrorKind)>,
     ) -> Option<Self> {
         match ev {
@@ -64,7 +64,7 @@ impl State {
 
     fn handle_key_down(
         mut self,
-        child: &WriterState,
+        child: &WriterVerifyState,
         kc: KeyCode,
         km: KeyModifiers,
     ) -> Option<Self> {

--- a/src/ui/fancy_ui/widgets.rs
+++ b/src/ui/fancy_ui/widgets.rs
@@ -13,10 +13,10 @@ use ratatui::{
     },
 };
 
-use crate::orchestrator::WriterState;
+use crate::orchestrator::WriterVerifyState;
 
 pub struct SpeedChart<'a> {
-    pub state: &'a WriterState,
+    pub state: &'a WriterVerifyState,
     pub final_time: Instant,
 }
 
@@ -133,9 +133,9 @@ pub struct WriterProgressBar {
 }
 
 impl WriterProgressBar {
-    pub fn from_writer(state: &WriterState) -> WriterProgressBar {
+    pub fn from_writer(state: &WriterVerifyState) -> WriterProgressBar {
         match state {
-            WriterState::Writing(st) => WriterProgressBar {
+            WriterVerifyState::Writing(st) => WriterProgressBar {
                 bytes_written: st.write_hist.bytes_encountered(),
                 label_state: "Burning...",
                 style: Style::default().fg(Color::Yellow),
@@ -143,7 +143,7 @@ impl WriterProgressBar {
                 display_total_bytes: st.total_raw_bytes,
             },
 
-            WriterState::Verifying {
+            WriterVerifyState::Verifying {
                 verify_hist,
                 total_write_bytes,
                 ..
@@ -154,20 +154,20 @@ impl WriterProgressBar {
                 Style::default().fg(Color::Blue).bg(Color::Yellow),
             ),
 
-            WriterState::Finished {
+            WriterVerifyState::Finished {
                 write_hist,
-                error,
+                result,
                 total_write_bytes,
                 ..
             } => WriterProgressBar::from_simple(
                 write_hist.bytes_encountered(),
                 *total_write_bytes,
-                if error.is_some() {
+                if result.is_err() {
                     "Error!"
                 } else {
                     "Done! Press q to quit."
                 },
-                if error.is_some() {
+                if result.is_err() {
                     Style::default().fg(Color::White).bg(Color::Red)
                 } else {
                     Style::default().fg(Color::Green).bg(Color::Black)
@@ -224,7 +224,7 @@ impl WriterProgressBar {
 pub struct WritingInfoTable<'a> {
     pub input_filename: &'a str,
     pub target_filename: &'a str,
-    pub state: &'a WriterState,
+    pub state: &'a WriterVerifyState,
 }
 
 impl WritingInfoTable<'_> {
@@ -241,13 +241,13 @@ impl WritingInfoTable<'_> {
         ];
 
         match &self.state {
-            WriterState::Writing(st) => {
+            WriterVerifyState::Writing(st) => {
                 rows.push(Row::new([
                     Cell::from("ETA Write"),
                     Cell::from(format!("{}", st.eta_write())),
                 ]));
             }
-            WriterState::Verifying {
+            WriterVerifyState::Verifying {
                 verify_hist: vdata,
                 total_write_bytes,
                 ..
@@ -261,7 +261,7 @@ impl WritingInfoTable<'_> {
                     Cell::from(format!("{}", vdata.estimated_time_left(*total_write_bytes))),
                 ]));
             }
-            WriterState::Finished {
+            WriterVerifyState::Finished {
                 verify_hist: vdata, ..
             } => {
                 if let Some(vdata) = vdata {

--- a/src/ui/simple_ui/mod.rs
+++ b/src/ui/simple_ui/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     logging::LogPaths,
     orchestrator::{
         Orchestrator, OrchestratorExt, StartWriterError, WriteVerifyParams, WriteVerifyStarted,
-        WriterState, watch::Watch,
+        WriterVerifyState, watch::Watch,
     },
     runtime::RemoteSpawn,
     ui::cli::UseSudo,
@@ -55,7 +55,7 @@ pub fn do_setup_wizard(args: &BurnArgs) -> Result<Option<WriteVerifyParams>, any
 }
 
 pub struct Params<'a> {
-    pub child_state: Watch<WriterState>,
+    pub child_state: Watch<WriterVerifyState>,
     pub log_paths: &'a LogPaths,
 }
 
@@ -140,10 +140,10 @@ pub fn run<'a>(params: Params<'a>) {
 
         let child_state = params.child_state.borrow();
         match &*child_state {
-            WriterState::Writing(b) => {
+            WriterVerifyState::Writing(b) => {
                 write_progress.set_position((b.approximate_ratio() * (length as f64)) as u64)
             }
-            WriterState::Verifying {
+            WriterVerifyState::Verifying {
                 verify_hist,
                 total_write_bytes,
                 ..
@@ -151,13 +151,13 @@ pub fn run<'a>(params: Params<'a>) {
                 let ratio = verify_hist.bytes_encountered() as f64 / *total_write_bytes as f64;
                 verify_progress.set_position((ratio * (length as f64)) as u64)
             }
-            WriterState::Finished { error, .. } => {
-                match error {
-                    Some(error) => {
+            WriterVerifyState::Finished { result, .. } => {
+                match result {
+                    Err(error) => {
                         println!("Error occurred while writing: {error}");
                         println!("{}", params.log_paths.get_bug_report_msg());
                     }
-                    None => {
+                    Ok(()) => {
                         println!("Done!")
                     }
                 }

--- a/src/util/candidate.rs
+++ b/src/util/candidate.rs
@@ -6,16 +6,19 @@
 //!
 //! Consider the task of determining what kind of file format a file has.
 //!
-//! - We can guess that the file is gzipped if it has a `.gz` extension, which can give us 24 bits of certainty:
-//!   eight for each byte in the extension.
-//! - If we find that the file in fact starts with `1f 8b`, the magic number for gzip, we can assign it
-//!   16 bits of certainty plus an additional fudge factor, maybe `PATH_MAX * 8`, for it being based on the actual
-//!   file contents rather than the file extension.
-//! - But then, if we happen to find `55 aa` at offset 510, designating a master boot record, that's now 16 bits of
-//!   certainty plus `PATH_MAX * 8` towards this file not being compressed at all!
+//! - We can guess that the file is gzipped if it has a `.gz` extension, which
+//!   can give us 24 bits of certainty: eight for each byte in the extension.
+//! - If we find that the file in fact starts with `1f 8b`, the magic number for
+//!   gzip, we can assign it 16 bits of certainty plus an additional fudge
+//!   factor, maybe `PATH_MAX * 8`, for it being based on the actual file
+//!   contents rather than the file extension.
+//! - But then, if we happen to find `55 aa` at offset 510, designating a master
+//!   boot record, that's now 16 bits of certainty plus `PATH_MAX * 8` towards
+//!   this file not being compressed at all!
 //!
-//! So now we have two reasons to guess that it's gzip, summing up to `16 + 24 + PATH_MAX * 8` bits of certainty,
-//! while we only have one reason to guess that it's a raw disk, summing up to `16 + PATH_MAX * 8`. The additional
+//! So now we have two reasons to guess that it's gzip, summing up to `16 + 24 +
+//! PATH_MAX * 8` bits of certainty, while we only have one reason to guess that
+//! it's a raw disk, summing up to `16 + PATH_MAX * 8`. The additional
 //! evidence from the file extension acts as a tiebreaker.
 
 use std::{
@@ -59,8 +62,8 @@ impl<T: Ord> Candidates<T> {
 /// A candidate value `T` combined with a list of [`Reason`]s it's listed as a
 /// candidate.
 ///
-/// The `T` must implement [`Ord`] to act as a tiebreaker in case there exist two candidates with the
-/// same certainty.
+/// The `T` must implement [`Ord`] to act as a tiebreaker in case there exist
+/// two candidates with the same certainty.
 pub struct Candidate<T: Ord> {
     value: T,
     reasons: Vec<Reason>,

--- a/src/util/candidate.rs
+++ b/src/util/candidate.rs
@@ -1,0 +1,185 @@
+#![expect(unused)]
+
+//! Utilities for working with multiple candidate values using [entropy](https://en.wikipedia.org/wiki/Entropy_(information_theory))-based probabilities.
+//!
+//! ## Concrete example of usage
+//!
+//! Consider the task of determining what kind of file format a file has.
+//!
+//! - We can guess that the file is gzipped if it has a `.gz` extension, which can give us 24 bits of certainty:
+//!   eight for each byte in the extension.
+//! - If we find that the file in fact starts with `1f 8b`, the magic number for gzip, we can assign it
+//!   16 bits of certainty plus an additional fudge factor, maybe `PATH_MAX * 8`, for it being based on the actual
+//!   file contents rather than the file extension.
+//! - But then, if we happen to find `55 aa` at offset 510, designating a master boot record, that's now 16 bits of
+//!   certainty plus `PATH_MAX * 8` towards this file not being compressed at all!
+//!
+//! So now we have two reasons to guess that it's gzip, summing up to `16 + 24 + PATH_MAX * 8` bits of certainty,
+//! while we only have one reason to guess that it's a raw disk, summing up to `16 + PATH_MAX * 8`. The additional
+//! evidence from the file extension acts as a tiebreaker.
+
+use std::{
+    cmp::Ordering,
+    iter::Sum,
+    ops::{Add, AddAssign},
+};
+
+/// A list of candidate values.
+pub struct Candidates<T: Ord> {
+    inner: Vec<Candidate<T>>,
+}
+
+impl<T: Ord> Candidates<T> {
+    pub fn new(inner: Vec<Candidate<T>>) -> Self {
+        Self { inner }
+    }
+
+    /// Get the likeliest candidate values stored here.
+    pub fn likeliest(&self) -> Vec<&Candidate<T>> {
+        // Get one maximum value
+        let Some(max) = self.inner.iter().max() else {
+            return vec![];
+        };
+
+        // Find all values with same certainty as the maximum value to search for ties
+        self.inner.iter().filter(|x| *x == max).collect()
+    }
+
+    /// Get a list of all candidates stored here.
+    pub fn all_candidates(&self) -> impl Iterator<Item = &Candidate<T>> {
+        self.inner.iter()
+    }
+
+    /// Add a candidate to this set.
+    pub fn add(&mut self, item: Candidate<T>) {
+        self.inner.push(item);
+    }
+}
+
+/// A candidate value `T` combined with a list of [`Reason`]s it's listed as a
+/// candidate.
+///
+/// The `T` must implement [`Ord`] to act as a tiebreaker in case there exist two candidates with the
+/// same certainty.
+pub struct Candidate<T: Ord> {
+    value: T,
+    reasons: Vec<Reason>,
+}
+
+impl<T: Ord> Candidate<T> {
+    pub fn new(value: T, reasons: Vec<Reason>) -> Self {
+        Self { value, reasons }
+    }
+
+    pub fn certainty(&self) -> Certainty {
+        self.reasons.iter().map(|x| x.certainty()).sum()
+    }
+
+    pub fn value(&self) -> &T {
+        &self.value
+    }
+
+    pub fn value_mut(&mut self) -> &mut T {
+        &mut self.value
+    }
+}
+
+impl<T: Ord> PartialEq for Candidate<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value && self.certainty() == other.certainty()
+    }
+}
+
+impl<T: Ord> Eq for Candidate<T> {}
+
+impl<T: Ord> PartialOrd for Candidate<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T: Ord> Ord for Candidate<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Compare certainties, then use the value itself as a tiebreaker
+        self.certainty()
+            .cmp(&other.certainty())
+            .then(self.value.cmp(&other.value))
+    }
+}
+
+/// Reason a value was provided as a candidate, combined with a certainty value
+/// it provides.
+pub struct Reason {
+    certainty: Certainty,
+    description: String,
+}
+
+impl Reason {
+    pub fn new(certainty: Certainty, description: String) -> Self {
+        Self {
+            certainty,
+            description,
+        }
+    }
+
+    /// How much certainty this reason adds to this candidate.
+    pub fn certainty(&self) -> Certainty {
+        self.certainty
+    }
+
+    /// A string describing what this reason is.
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+}
+
+/// A representation of how certain something is.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum Certainty {
+    /// Partial (or zero) certainty, represented in bits.
+    Partial(u64),
+
+    /// Perfect certainty (infinity bits).
+    Perfect,
+}
+
+impl Certainty {
+    pub fn zero() -> Self {
+        Certainty::Partial(0)
+    }
+}
+
+impl Default for Certainty {
+    fn default() -> Self {
+        Certainty::zero()
+    }
+}
+
+impl Add<Self> for Certainty {
+    type Output = Certainty;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (Certainty::Partial(l), Certainty::Partial(r)) => {
+                Certainty::Partial(u64::saturating_add(l, r))
+            }
+            (Certainty::Perfect, _) | (_, Certainty::Perfect) => Certainty::Perfect,
+        }
+    }
+}
+
+impl AddAssign<Self> for Certainty {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl Sum for Certainty {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        let mut acc = Certainty::default();
+        for i in iter {
+            acc += i;
+        }
+        acc
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -2,6 +2,8 @@ use std::{
     env, fs::DirBuilder, os::unix::fs::DirBuilderExt as _, path::PathBuf, process, time::SystemTime,
 };
 
+pub mod candidate;
+
 /// Create the directory to shove invocation-specific data into, like log files
 /// and sockets.
 pub fn ensure_state_dir() -> std::io::Result<PathBuf> {


### PR DESCRIPTION
## Summary

Adds new stub methods onto Orchestrator. No implementations yet.

- `analyze_input()` is the new interface for reading a file and guessing what's inside. The intended workflow is that you call it once, to fill up your UI's wizard with data, and then ask the user if there's anything that's not certain.
- `watch_disks()` is the new interface for querying what disks are available. I want to support hotplug detection later so this interface is suitable for that.
- `start_hash()` is the new interface for hashing files on a background thread and watching its progress.

The interface definitions are subject to change a bit, but I'm pretty settled on this overall shape.

Unless I'm missing anything else, #240 should now be able to progress independently from the rest of my refactor work!

## Type of change

<!-- Check boxes as applicable. Please add more options if you feel that they are relevant. -->

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] This change requires a documentation update
- [ ] This change contains modifications to the `--help` output
    - [ ] I ran `scripts/regenerate_readme.py` from the root directory to ensure it has the latest sample output

## Test plan

CI
