### PR TITLE
Handle non-panic errors more gracefully

### DIFF
--- a/nix/devvm/README.md
+++ b/nix/devvm/README.md
@@ -2,16 +2,16 @@
 
 This command runs a VM in your terminal and mounts your PWD to `/tmp/shared` inside the VM. 
 
-Generally, this should be run in the root of this project.
+This should be run from the root directory of this project in order to work correctly.
 
 ```sh
-SHARED_DIR=$PWD nix run .#devvm-aarch64-linux 
+nix run .#devvm-aarch64-linux 
 ```
 
 You may have to cross-compile using a remote machine. In that case, you can put builders in like so ([see Nix docs for more info](https://nix.dev/manual/nix/2.18/advanced-topics/distributed-builds)):
 
 ```sh
-SHARED_DIR=$PWD nix run --builders 'ssh://astrid@your-host.example aarch64-linux' .#devvm-aarch64-linux 
+nix run --builders 'ssh://astrid@your-host.example aarch64-linux' .#devvm-aarch64-linux 
 ```
 
 Note that you may or may not have to `sudo` cargo commands inside the VM.

--- a/nix/devvm/usbhotplug.sh
+++ b/nix/devvm/usbhotplug.sh
@@ -11,15 +11,32 @@ validate_variable() {
 print_help() {
     echo "Caligula DevVM USB hotplugger"
     echo "Usage:"
-    printf "\t%s add <name> <size>\n" "$0"
+    printf "\t%s add [--ro] <name> <size>\n" "$0"
     printf "\t%s rm <name>\n" "$0"
 }
 
 to_qemu() {
-    nc -NU /tmp/caligula-devvm-monitor.sock
+    nc -NU ./devvm.sock
 }
 
 add_usb() {
+    extra_flags=""
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --ro)
+                extra_flags="$extra_flags,readonly=on"
+                shift
+                ;;
+            -*|--*)
+                echo "Unknown option $1"
+                exit 1
+                ;;
+            *)
+                break
+            ;;
+        esac
+    done
+
     validate_variable "name" "${1:-}"
     validate_variable "size" "${2:-}"
 
@@ -30,7 +47,7 @@ add_usb() {
     set -euxo pipefail
 
     truncate -s "$size" "$file"
-    echo "drive_add 0 if=none,id=drive-$name,format=raw,file=$file" | to_qemu
+    echo "drive_add 0 if=none,id=drive-$name,format=raw,file=$file$extra_flags" | to_qemu
     echo "device_add usb-storage,bus=xhci.0,drive=drive-$name,removable=on,id=device-$name" | to_qemu
 }
 

--- a/nix/devvm/usbhotplug.sh
+++ b/nix/devvm/usbhotplug.sh
@@ -27,7 +27,7 @@ add_usb() {
                 extra_flags="$extra_flags,readonly=on"
                 shift
                 ;;
-            -*|--*)
+            --*|-*)
                 echo "Unknown option $1"
                 exit 1
                 ;;

--- a/src/herder_api/error.rs
+++ b/src/herder_api/error.rs
@@ -1,0 +1,124 @@
+use std::{error::Error, fmt::Display, io};
+
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+/// A serializable [`std::io::Error`] that supports converting it into specific,
+/// recognizable kinds of errors.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+pub struct IoError<K: Error> {
+    kind: Option<K>,
+    raw_error: String,
+}
+
+impl<K: Error> IoError<K> {
+    pub fn kind(&self) -> Option<&K> {
+        self.kind.as_ref()
+    }
+}
+
+impl<K: Error> Display for IoError<K> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.kind {
+            Some(kind) => match f.alternate() {
+                true => write!(f, "{kind} (raw error: {}", self.raw_error),
+                false => write!(f, "{kind}"),
+            },
+            None => write!(f, "Unknown I/O error: {}", self.raw_error),
+        }
+    }
+}
+
+impl<K> From<std::io::Error> for IoError<K>
+where
+    K: Error + TryFrom<std::io::Error>,
+{
+    fn from(value: std::io::Error) -> Self {
+        let raw_error = value.to_string();
+        let kind = K::try_from(value).ok();
+        Self { kind, raw_error }
+    }
+}
+
+/// Errors that come up when running one-off shell commands.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+pub enum UnmountError {
+    #[error("Error executing diskutil unmount: {0}")]
+    Diskutil(CommandError),
+}
+
+/// Errors that come up when running one-off shell commands.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+pub enum CommandError {
+    #[error("Command exited with exit code {exit:?}!\nstdout: {stdout:?}\nstderr: {stderr:?}")]
+    NonzeroExit {
+        exit: Option<i32>,
+        stdout: String,
+        stderr: String,
+    },
+    #[error("Error managing subprocess: {0}")]
+    Process(IoError<UnrecoverableIoError>),
+    #[error("Error communicating with subprocess: {0}")]
+    Comm(IoError<UnrecoverableIoError>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+#[error("This error cannot be recovered from!")]
+pub struct UnrecoverableIoError;
+
+impl TryFrom<std::io::Error> for UnrecoverableIoError {
+    type Error = std::io::Error;
+
+    fn try_from(value: std::io::Error) -> Result<Self, Self::Error> {
+        Err(value)
+    }
+}
+
+/// Errors that come up when opening or reading the input file.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+pub enum InputFileError {
+    #[error("Permission denied while opening file!")]
+    PermissionDenied,
+    #[error("File was not found! Was it moved or deleted?")]
+    NotFound,
+}
+
+impl TryFrom<std::io::Error> for InputFileError {
+    type Error = std::io::Error;
+
+    fn try_from(value: std::io::Error) -> Result<Self, Self::Error> {
+        debug!("Attempting to convert std::io::Error into a known value: {value:?}");
+        match value.kind() {
+            io::ErrorKind::PermissionDenied => Ok(Self::PermissionDenied),
+            io::ErrorKind::NotFound => Ok(Self::NotFound),
+            _ => Err(value),
+        }
+    }
+}
+
+/// Errors that come up when opening or reading the output file.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error)]
+pub enum DiskError {
+    #[error("Permission denied while opening file!")]
+    PermissionDenied,
+    #[error(
+        "File is read-only! If we've already become root, this thing simply cannot be written to!"
+    )]
+    ReadOnly,
+    #[error("File was not found! Was it ejected?")]
+    NotFound,
+}
+
+impl TryFrom<std::io::Error> for DiskError {
+    type Error = std::io::Error;
+
+    fn try_from(value: std::io::Error) -> Result<Self, Self::Error> {
+        debug!("Attempting to convert std::io::Error into a known value: {value:?}");
+        match value.kind() {
+            io::ErrorKind::PermissionDenied => Ok(Self::PermissionDenied),
+            io::ErrorKind::NotFound => Ok(Self::NotFound),
+            io::ErrorKind::ReadOnlyFilesystem => Ok(Self::ReadOnly),
+            _ => Err(value),
+        }
+    }
+}

--- a/src/herder_api/mod.rs
+++ b/src/herder_api/mod.rs
@@ -4,6 +4,7 @@
 //! The UI may speak some of these types, but it should prefer to use the
 //! higher-level interfaces defined in [`crate::facade`].
 
+pub mod error;
 pub mod write_verify;
 
 use std::fmt::{Debug, Display};

--- a/src/herder_api/write_verify.rs
+++ b/src/herder_api/write_verify.rs
@@ -3,7 +3,11 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use super::HerdAction;
-use crate::{compression::CompressionFormat, device::Type};
+use crate::{
+    compression::CompressionFormat,
+    device::Type,
+    herder_api::error::{DiskError, InputFileError, IoError, UnmountError},
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WriteVerifyAction {
@@ -69,23 +73,16 @@ pub struct WriteVerifyStart {
 pub enum LegacyWriteVerifyError {
     #[error("Unexpected end of output file. Is your output file too small?")]
     EndOfOutput,
-    #[error("Permission denied while opening file")]
-    PermissionDenied,
-    #[error("Disk verification failed!")]
-    VerificationFailed,
-    #[error("The child process unexpectedly terminated!")]
-    UnexpectedTermination,
     #[error("Unknown error occurred in child process: {0}")]
     UnknownChildProcError(String),
-    #[error("Failed to unmount disk (exit code {exit_code})\n{message}")]
-    FailedToUnmount { message: String, exit_code: i32 },
-}
-
-impl From<std::io::Error> for LegacyWriteVerifyError {
-    fn from(value: std::io::Error) -> Self {
-        match value.kind() {
-            std::io::ErrorKind::PermissionDenied => Self::PermissionDenied,
-            _ => Self::UnknownChildProcError(format!("{value:#}")),
-        }
-    }
+    #[error("Failed to unmount disk: {0}")]
+    FailedToUnmount(#[from] UnmountError),
+    #[error("The child process unexpectedly terminated!")]
+    UnexpectedTermination,
+    #[error("Disk verification failed!")]
+    VerificationFailed,
+    #[error("Error handling input: {0}")]
+    InputFile(#[from] IoError<InputFileError>),
+    #[error("Error handling output: {0}")]
+    OutputFile(#[from] IoError<DiskError>),
 }

--- a/src/herder_daemon/writer_process.rs
+++ b/src/herder_daemon/writer_process.rs
@@ -6,7 +6,6 @@
 use std::{
     fs::{File, OpenOptions},
     io::{self, Read, Seek},
-    os::unix::process::ExitStatusExt,
     process::{Command, Stdio},
     thread::JoinHandle,
 };
@@ -16,7 +15,10 @@ use tracing_unwrap::ResultExt;
 
 use crate::{
     device,
-    herder_api::write_verify::*,
+    herder_api::{
+        error::{CommandError, DiskError, InputFileError, IoError, UnmountError},
+        write_verify::*,
+    },
     legacy_io::{SyncDataFile, VerifyOp, WriteOp, open_blockdev},
 };
 
@@ -53,39 +55,16 @@ fn run(
     args: &WriteVerifyAction,
 ) -> Result<(), LegacyWriteVerifyError> {
     if cfg!(target_os = "macos") && args.target_type == device::Type::Disk {
-        let mut command = Command::new("diskutil");
-        command
-            .arg("unmountdisk")
-            .arg(&args.dest)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        info!(?command, "spawning process to unmount disk");
-        let mut child = command.spawn()?;
-        debug!("successfully ran diskutil, waiting on child process");
-
-        let exit = child.wait()?;
-        let mut stderr = String::new();
-        child.stderr.take().unwrap().read_to_string(&mut stderr)?;
-        let mut stdout = String::new();
-        child.stdout.take().unwrap().read_to_string(&mut stdout)?;
-
-        debug!(?exit, ?stderr, "child exited");
-
-        let exit_code = exit.into_raw();
-        if !exit.success() {
-            return Err(LegacyWriteVerifyError::FailedToUnmount {
-                message: format!("stderr: {stderr}\nstdout: {stdout}"),
-                exit_code,
-            });
-        }
+        run_diskutil_umount(args).map_err(UnmountError::Diskutil)?;
     }
 
     info!("Opening file {}", args.src.to_string_lossy());
     let mut file = File::open(&args.src).unwrap_or_log();
-    let size = file.seek(io::SeekFrom::End(0))?;
-    file.seek(io::SeekFrom::Start(0))?;
+    let size = file
+        .seek(io::SeekFrom::End(0))
+        .map_err(IoError::<InputFileError>::from)?;
+    file.seek(io::SeekFrom::Start(0))
+        .map_err(IoError::<InputFileError>::from)?;
 
     info!(size, "Got input file size");
 
@@ -97,9 +76,10 @@ fn run(
             .write(true)
             .create(true)
             .truncate(true)
-            .open(&args.dest)?,
+            .open(&args.dest)
+            .map_err(IoError::<DiskError>::from)?,
         device::Type::Disk | device::Type::Partition => {
-            open_blockdev(&args.dest, args.compression)?
+            open_blockdev(&args.dest, args.compression).map_err(IoError::<DiskError>::from)?
         }
     });
 
@@ -138,15 +118,19 @@ fn run(
     }
 
     info!("Rewinding source and target to beginning");
-    file.seek(io::SeekFrom::Start(0))?;
-    disk.seek(io::SeekFrom::Start(0))?;
+    file.seek(io::SeekFrom::Start(0))
+        .map_err(IoError::<InputFileError>::from)?;
+    disk.seek(io::SeekFrom::Start(0))
+        .map_err(IoError::<DiskError>::from)?;
 
     if args.target_type == device::Type::File {
         info!(
             ?actual_input_bytes,
             "Output is a file, truncating to input length in case we wrote too much"
         );
-        disk.0.set_len(actual_input_bytes)?;
+        disk.0
+            .set_len(actual_input_bytes)
+            .map_err(IoError::<DiskError>::from)?;
     };
 
     info!("Executing verification");
@@ -160,6 +144,51 @@ fn run(
         file_read_buf_size: buf_size,
     }
     .execute(tx)?;
+
+    Ok(())
+}
+
+/// Raw routine to execute `diskutil unmountdisk` on MacOS.
+fn run_diskutil_umount(args: &WriteVerifyAction) -> Result<(), CommandError> {
+    let mut command = Command::new("diskutil");
+    command
+        .arg("unmountdisk")
+        .arg(&args.dest)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    info!(?command, "spawning process to unmount disk");
+    let mut child = command
+        .spawn()
+        .map_err(|e| CommandError::Process(e.into()))?;
+
+    debug!("successfully ran diskutil, waiting on child process");
+    let exit = child.wait().map_err(|e| CommandError::Process(e.into()))?;
+
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .map_err(|e| CommandError::Comm(e.into()))?;
+    let mut stdout = String::new();
+    child
+        .stdout
+        .take()
+        .unwrap()
+        .read_to_string(&mut stdout)
+        .map_err(|e| CommandError::Comm(e.into()))?;
+
+    debug!(?exit, ?stderr, "child exited");
+
+    if !exit.success() {
+        return Err(CommandError::NonzeroExit {
+            exit: exit.code(),
+            stderr,
+            stdout,
+        });
+    }
 
     Ok(())
 }

--- a/src/legacy_io/verify.rs
+++ b/src/legacy_io/verify.rs
@@ -4,7 +4,10 @@ use aligned_vec::avec_rt;
 
 use crate::{
     compression::CompressionFormat,
-    herder_api::write_verify::{LegacyWriteVerifyError, WriteVerifyEvent},
+    herder_api::{
+        error::{DiskError, InputFileError, IoError},
+        write_verify::{LegacyWriteVerifyError, WriteVerifyEvent},
+    },
     legacy_io::utils::{CountRead, FileSourceReader, try_read_exact},
 };
 
@@ -54,13 +57,14 @@ impl<S: Read, D: Read> VerifyOp<S, D> {
 
         loop {
             for _ in 0..self.checkpoint_period {
-                let file_read_bytes = try_read_exact(&mut file, &mut file_buf)?;
+                let file_read_bytes = try_read_exact(&mut file, &mut file_buf)
+                    .map_err(IoError::<InputFileError>::from)?;
                 if file_read_bytes == 0 {
                     checkpoint!();
                     return Ok(());
                 }
 
-                try_read_exact(&mut disk, &mut disk_buf)?;
+                try_read_exact(&mut disk, &mut disk_buf).map_err(IoError::<DiskError>::from)?;
 
                 if file_buf[..file_read_bytes] != disk_buf[..file_read_bytes] {
                     tracing::warn!(file_read_bytes, "verification failed");

--- a/src/legacy_io/write.rs
+++ b/src/legacy_io/write.rs
@@ -4,7 +4,10 @@ use aligned_vec::avec_rt;
 
 use crate::{
     compression::CompressionFormat,
-    herder_api::write_verify::{LegacyWriteVerifyError, WriteVerifyEvent},
+    herder_api::{
+        error::{DiskError, InputFileError, IoError},
+        write_verify::{LegacyWriteVerifyError, WriteVerifyEvent},
+    },
     legacy_io::utils::{CountWrite, FileSourceReader, try_read_exact},
 };
 
@@ -53,9 +56,10 @@ impl<S: Read, D: Write> WriteOp<S, D> {
         loop {
             for _ in 0..self.checkpoint_period {
                 // Try to fill up the block if we can.
-                let read_bytes = try_read_exact(&mut file, &mut buf)?;
+                let read_bytes =
+                    try_read_exact(&mut file, &mut buf).map_err(IoError::<InputFileError>::from)?;
                 if read_bytes == 0 {
-                    disk.flush()?;
+                    disk.flush().map_err(IoError::<DiskError>::from)?;
                     checkpoint!();
                     return Ok(file.decompressed_bytes());
                 }
@@ -63,7 +67,7 @@ impl<S: Read, D: Write> WriteOp<S, D> {
                 // Write the entire buffer, because we're doing direct writes.
                 // Even if we didn't fill the whole buffer, we are still writing the whole
                 // buffer.
-                let written_bytes = disk.write(&buf[..])?;
+                let written_bytes = disk.write(&buf[..]).map_err(IoError::<DiskError>::from)?;
                 if written_bytes == 0 {
                     checkpoint!();
                     return Err(LegacyWriteVerifyError::EndOfOutput);

--- a/src/logging/error.rs
+++ b/src/logging/error.rs
@@ -1,0 +1,179 @@
+use std::{
+    fmt::{Debug, Display},
+    io::Write,
+};
+
+use crossterm::{style::Stylize, terminal::disable_raw_mode};
+
+use crate::logging::coredump::CoredumpInstructions;
+
+/// An error augmented with a function for generating [`ErrorInfo`] out of it,
+/// containing information to print in [`crash_and_burn()`] implementations.
+// TODO: kill anyhow and make it `: Error` instead of `Display + Debug`
+pub trait ErrorWithInfo: Display + Debug {
+    /// Get the [`ErrorInfo`].
+    fn error_info(&self) -> ErrorInfo;
+}
+
+impl ErrorWithInfo for anyhow::Error {
+    fn error_info(&self) -> ErrorInfo {
+        ErrorInfo {
+            severity: ErrorSeverity::Fatal,
+            remediation: RemediationAdvice::Transient,
+        }
+    }
+}
+
+/// Cause this program to fatally exit and print out a big error for the user to
+/// read.
+pub fn crash_and_burn(ctx: &ErrorContext, error: impl ErrorWithInfo) {
+    tracing::error!("Crashing and burning with error! {error}");
+    tracing::error!("Full debug of error: {error:#?}");
+    tracing::error!("Full info of error: {:#?}", error.error_info());
+
+    disable_raw_mode().ok();
+
+    write_error_message_to_terminal(std::io::stderr(), ctx, error).ok();
+
+    // abort to trigger coredump
+    unsafe {
+        libc::abort();
+    }
+}
+
+fn write_error_message_to_terminal(
+    mut w: impl Write,
+    ctx: &ErrorContext,
+    error: impl ErrorWithInfo,
+) -> std::io::Result<()> {
+    let info = error.error_info();
+    let header = match info.severity {
+        ErrorSeverity::Panic => "!!! PROGRAM PANICKED !!!",
+        ErrorSeverity::Fatal => "Caligula encountered a fatal error and had to abort!",
+        ErrorSeverity::Recoverable => {
+            "Caligula could not recover from an error it should have recovered from!"
+        }
+    };
+
+    writeln!(w, "{}", header.bold().red())?;
+    writeln!(w, "{}", error.to_string().red())?;
+    writeln!(w)?;
+
+    match info.remediation {
+        RemediationAdvice::DeveloperError => {
+            writeln!(
+                w,
+                "{}",
+                "This is most likely a bug caused by developer error."
+                    .bold()
+                    .yellow()
+            )?;
+
+            writeln!(
+                w,
+                "{} {}",
+                "We would highly appreciate it if you reported it to the bug tracker:".yellow(),
+                super::ISSUE_TRACKER_URL.bold().yellow()
+            )?;
+
+            writeln!(
+                w,
+                "{} {}",
+                "Please include this log file in your bug report:".yellow(),
+                ctx.log_path.clone().bold().yellow()
+            )?;
+            writeln!(w)?;
+        }
+        RemediationAdvice::Transient => {
+            writeln!(
+                w,
+                "{} {}",
+                "This is most likely a transient issue.".bold().yellow(),
+                "Please try running the program again. If that doesn't work, please check your \
+                 system and hardware configuration."
+                    .yellow()
+            )?;
+
+            writeln!(
+                w,
+                "{} {}",
+                "If issues still persist, we would highly appreciate it if you reported it to the \
+                 bug tracker:"
+                    .yellow(),
+                super::ISSUE_TRACKER_URL.bold().yellow()
+            )?;
+
+            writeln!(
+                w,
+                "{}{}",
+                "Please include this log file in your bug report: ".yellow(),
+                ctx.log_path.clone().bold().yellow()
+            )?;
+            writeln!(w)?;
+        }
+    };
+
+    write_coredump_instructions(&mut w, ctx)?;
+
+    // add extra newlines at end to break the "core dumped" message onto its own
+    // line
+    write!(w, "\n\n")?;
+
+    Ok(())
+}
+
+fn write_coredump_instructions(
+    mut w: impl Write,
+    ctx: &ErrorContext,
+) -> Result<(), std::io::Error> {
+    writeln!(
+        w,
+        "{}",
+        "Though it's not required when reporting issues, it would help with debugging if you \
+         attached a coredump in addition to your logs."
+            .bold()
+            .cyan(),
+    )?;
+    writeln!(w, "{}", ctx.coredump_instructions.to_string().cyan())?;
+    Ok(())
+}
+
+/// Information to print to the user.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ErrorInfo {
+    pub severity: ErrorSeverity,
+    pub remediation: RemediationAdvice,
+}
+
+pub struct ErrorContext {
+    pub log_path: String,
+    pub coredump_instructions: CoredumpInstructions,
+}
+
+/// How bad this error is.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ErrorSeverity {
+    /// It's a panic. Panics should never ever happen in this program, but they
+    /// still sometimes happen, so really only the panic hook sets this value.
+    Panic,
+
+    /// It's not a panic, but it's still some kind of error we can't reasonably
+    /// expect to recover from.
+    Fatal,
+
+    /// It's an error we expect to be able to recover from. If this bubbles up
+    /// to the error handler, there's a chance that we didn't handle the error
+    /// correctly.
+    #[expect(unused)]
+    Recoverable,
+}
+
+/// Advice to give the user for remediating this error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RemediationAdvice {
+    /// This error is entirely the developer's fault.
+    DeveloperError,
+
+    /// This error is likely transient.
+    Transient,
+}

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -1,19 +1,20 @@
 mod coredump;
+mod error;
 
 use std::{
+    self,
     collections::BTreeMap,
     fs::File,
-    io::Write,
     panic::{PanicHookInfo, set_hook},
     path::Path,
-    sync::Mutex,
+    sync::{Arc, Mutex},
 };
 
-use crossterm::{style::Stylize, terminal::disable_raw_mode};
+pub use error::{ErrorContext, ErrorInfo, ErrorSeverity, ErrorWithInfo, crash_and_burn};
 use tracing::{Level, info, warn};
 use tracing_subscriber::{EnvFilter, fmt::format::FmtSpan};
 
-use crate::logging::coredump::CoredumpInstructions;
+use crate::logging::error::RemediationAdvice;
 
 const ISSUE_TRACKER_URL: &str = "https://github.com/ifd3f/caligula/issues";
 
@@ -57,7 +58,7 @@ const FILE_LOG_LEVEL: Level = Level::DEBUG;
 #[cfg(debug_assertions)]
 const FILE_LOG_LEVEL: Level = Level::TRACE;
 
-pub fn init_logging_parent(paths: &LogPaths) {
+pub fn init_logging_parent(paths: &LogPaths) -> Arc<error::ErrorContext> {
     let log_path = paths.main().to_owned();
     let file = File::create(&log_path).expect("Failed to create log file!");
 
@@ -68,77 +69,36 @@ pub fn init_logging_parent(paths: &LogPaths) {
     log_info_files();
     log_environment_variables();
 
-    let core_dump_msg = self::coredump::instructions();
-    info!("Guessed system coredump handler to be {core_dump_msg:?}");
+    let coredump_instructions = self::coredump::instructions();
+    info!("Guessed system coredump handler to be {coredump_instructions:?}");
+
+    let error_context = Arc::new(error::ErrorContext {
+        log_path,
+        coredump_instructions,
+    });
+
+    let ctx = error_context.clone();
 
     set_hook(Box::new(move |p| {
         tracing_panic::panic_hook(p);
 
-        disable_raw_mode().ok();
-
-        PanicMessage {
-            panic: p,
-            log_path: &log_path,
-            coredump_instructions: &core_dump_msg,
-        }
-        .write_to(std::io::stderr())
-        .ok();
-
-        // abort to trigger coredump
-        unsafe {
-            libc::abort();
-        }
+        crash_and_burn(&ctx, PanicError(p));
     }));
+
+    error_context
 }
 
-struct PanicMessage<'a> {
-    panic: &'a PanicHookInfo<'a>,
-    log_path: &'a str,
-    coredump_instructions: &'a CoredumpInstructions,
-}
+/// Simple wrapper for panic info that implements [`ErrorWithInfo`].
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+struct PanicError<'a>(&'a PanicHookInfo<'a>);
 
-impl<'a> PanicMessage<'a> {
-    fn write_to(&self, mut w: impl Write) -> std::io::Result<()> {
-        writeln!(w, "{}", "!!! PROGRAM PANICKED !!!".bold().red())?;
-        writeln!(w, "{}", self.panic.to_string().red())?;
-        writeln!(w)?;
-
-        writeln!(
-            w,
-            "{}",
-            "This is likely a bug caused by developer error."
-                .bold()
-                .yellow()
-        )?;
-        writeln!(
-            w,
-            "{}{}",
-            "We would highly appreciate it if you reported it here: ".yellow(),
-            ISSUE_TRACKER_URL.bold().yellow()
-        )?;
-        writeln!(
-            w,
-            "{}{}",
-            "Please include this log file in your bug report: ".yellow(),
-            self.log_path.bold().yellow()
-        )?;
-        writeln!(w)?;
-
-        writeln!(
-            w,
-            "{}",
-            "Though it's not required, it would help with debugging if you attached a coredump in \
-             addition to your logs."
-                .bold()
-                .cyan(),
-        )?;
-        writeln!(w, "{}", self.coredump_instructions.to_string().cyan())?;
-
-        // add extra newlines at end to break the "core dumped" message onto its own
-        // line
-        write!(w, "\n\n")?;
-
-        Ok(())
+impl<'a> ErrorWithInfo for PanicError<'a> {
+    fn error_info(&self) -> ErrorInfo {
+        ErrorInfo {
+            severity: ErrorSeverity::Panic,
+            remediation: RemediationAdvice::DeveloperError,
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use clap::{CommandFactory as _, Parser};
 use tracing::debug;
 
-use crate::facade::make_real_facade;
+use crate::{
+    facade::make_real_facade,
+    logging::{ErrorContext, crash_and_burn},
+};
 
 mod benchmarking;
 mod byteseries;
@@ -64,7 +67,7 @@ fn main() {
         Command::Burn(burn_args) => {
             let state_dir = util::ensure_state_dir().unwrap();
             let log_paths = logging::LogPaths::init(&state_dir);
-            logging::init_logging_parent(&log_paths);
+            let error_context = logging::init_logging_parent(&log_paths);
 
             let runtime = crate::runtime::AsyncRuntime::start();
             let facade = Arc::new(make_real_facade(log_paths.main()));
@@ -72,7 +75,7 @@ fn main() {
             debug!("Starting primary process");
             match ui::main(runtime, facade, log_paths.into(), burn_args) {
                 Ok(_) => (),
-                Err(e) => handle_toplevel_error(e),
+                Err(e) => handle_toplevel_error(&error_context, e),
             }
         }
         Command::HerderDaemon(args) => {
@@ -83,7 +86,7 @@ fn main() {
     }
 }
 
-fn handle_toplevel_error(err: anyhow::Error) {
+fn handle_toplevel_error(ctx: &ErrorContext, err: anyhow::Error) {
     use inquire::InquireError;
 
     if let Some(e) = err.downcast_ref::<InquireError>() {
@@ -91,11 +94,11 @@ fn handle_toplevel_error(err: anyhow::Error) {
             InquireError::OperationCanceled
             | InquireError::OperationInterrupted
             | InquireError::NotTTY => eprintln!("{e}"),
-            _ => panic!("{err}"),
+            _ => (),
         }
-    } else {
-        panic!("{err}");
     }
+
+    crash_and_burn(ctx, err);
 }
 
 /// Parse [Args] from the provided args, but format the help in an easy way for

--- a/src/ui/simple_ui/mod.rs
+++ b/src/ui/simple_ui/mod.rs
@@ -22,7 +22,7 @@ use crate::{
         CaligulaFacade, DaemonError, WVState, WriteVerifyWorkflow, watch::Watch,
         workflow::write_verify::WriteVerifyWorkflowError,
     },
-    herder_api::write_verify::LegacyWriteVerifyError,
+    herder_api::{error::DiskError, write_verify::LegacyWriteVerifyError},
     logging::LogPaths,
     runtime::RemoteSpawn,
     ui::cli::UseSudo,
@@ -67,6 +67,8 @@ pub enum WriteOrEscalateError {
     Write(#[from] Arc<WriteVerifyWorkflowError>),
     #[error("Error escalating: {0}")]
     Escalate(#[from] DaemonError),
+    #[error("Not allowed to escalate")]
+    NotAllowedToEscalate,
 }
 
 /// Attempt to start burning the disk with the given params.
@@ -87,44 +89,56 @@ pub fn try_start_write_or_escalate(
         .clone()
         .start_write_verify_blocking(runtime, args.clone())
     {
-        Ok(p) => {
-            return Ok(p);
-        }
+        Ok(p) => return Ok(p),
         Err(e) => e,
     };
 
-    if let WriteVerifyWorkflowError::Worker(LegacyWriteVerifyError::PermissionDenied) = err.as_ref()
-    {
-        tracing::info!("Unescalated burn failed");
-        match (root, interactive) {
-            (UseSudo::Ask, true) => {
-                debug!("Failure due to insufficient perms, asking user to escalate");
+    tracing::info!("Unescalated burn failed with error, attempting to recover: {err}");
 
-                let response = Confirm::new(&format!(
-                    "We don't have permissions on {}. Escalate using sudo?",
-                    args.target.name
-                ))
-                .with_default(true)
-                .with_help_message(
-                    "We will use the sudo command, which may prompt you for a password.",
-                )
-                .prompt()
-                .expect("prompting the user should not fail");
+    match err.as_ref() {
+        WriteVerifyWorkflowError::Worker(e) => match e {
+            LegacyWriteVerifyError::OutputFile(e)
+                if e.kind() == Some(&DiskError::PermissionDenied) =>
+            {
+                request_escalation(runtime, facade.clone(), root, interactive, args)?;
+                Ok(facade.start_write_verify_blocking(runtime, args.clone())?)
+            }
+            _ => Err(err.into()),
+        },
+        error => panic!("An unrecoverable developer error occurred: {error}"),
+    }
+}
 
-                if response {
-                    facade.clone().escalate_blocking(runtime, None)?;
-                    return Ok(facade.start_write_verify_blocking(runtime, args.clone())?);
-                }
+fn request_escalation(
+    runtime: &impl RemoteSpawn,
+    facade: Arc<impl CaligulaFacade>,
+    root: UseSudo,
+    interactive: bool,
+    args: &WriteVerifyWorkflow,
+) -> Result<(), WriteOrEscalateError> {
+    match (root, interactive) {
+        (UseSudo::Ask, true) => {
+            debug!("Failure due to insufficient perms, asking user to escalate");
+
+            let response = Confirm::new(&format!(
+                "We don't have permissions on {}. Escalate using sudo?",
+                args.target.name
+            ))
+            .with_default(true)
+            .with_help_message("We will use the sudo command, which may prompt you for a password.")
+            .prompt()
+            .expect("prompting the user should not fail");
+
+            if !response {
+                return Err(WriteOrEscalateError::NotAllowedToEscalate);
             }
-            (UseSudo::Always, _) => {
-                facade.clone().escalate_blocking(runtime, None)?;
-                return Ok(facade.start_write_verify_blocking(runtime, args.clone())?);
-            }
-            _ => {}
         }
+        (UseSudo::Always, _) => (),
+        _ => return Err(WriteOrEscalateError::NotAllowedToEscalate),
     }
 
-    Err(err)?
+    facade.escalate_blocking(runtime, None)?;
+    Ok(())
 }
 
 /// Run the simple TUI.


### PR DESCRIPTION
## Summary

Closes #172. Mostly.

I made child process errors more fine-grained, and reused the panic message apparatus to print a nice big error message.

There's a bit of inconsistency/conflicting info in the instructions ("File is read-only! If we've already become root, this thing simply cannot be written to!" vs "This is most likely a transient issue.") but it's better than before, which just incorrectly said "developer error". I'll fix the language later but it's good enough for now.

## Type of change

<!-- Check boxes as applicable. Please add more options if you feel that they are relevant. -->

- [x] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] This change requires a documentation update
- [ ] This change contains modifications to the `--help` output
    - [ ] I ran `scripts/regenerate_readme.py` from the root directory to ensure it has the latest sample output

## Test plan

<img width="2390" height="991" alt="image" src="https://github.com/user-attachments/assets/8c5e8efc-8003-4b73-9259-fe9f2d1b75b3" />
