### PR TITLE
consolidate unsafe bytesmut usage into a few helpers

### DIFF
--- a/src/facade/workflow/hash.rs
+++ b/src/facade/workflow/hash.rs
@@ -213,14 +213,14 @@ fn run_thread(
 ) -> Result<Bytes, HashingError> {
     std::thread::scope(move |s| -> Result<Bytes, HashingError> {
         // ensure file can be opened
-        let file = FileReader::new(&wf.file, 65536).map_err(HashingError::Read)?;
+        let file = FileReader::new(&wf.file).map_err(HashingError::Read)?;
         let file_size = file.size();
 
         // construct the other nodes in the graph
         let hash = wf.alg.hash_worker();
         let decompressor = match wf.compression {
             CompressionFormat::Identity => None,
-            other => Some(DecompressorWorker::new(other, 65536)),
+            other => Some(DecompressorWorker::new(other)),
         };
 
         // calculate pipeline topology and what buffers are needed to connect things

--- a/src/io_graph/mod.rs
+++ b/src/io_graph/mod.rs
@@ -1,4 +1,5 @@
 use std::{
+    alloc::Layout,
     error::Error,
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -16,6 +17,25 @@ mod buf;
 mod junction;
 pub mod util;
 pub mod worker;
+
+/// [`Layout`] to allocate buffer pages with.
+///
+/// Later on we probably want to figure out how to auto-tune these values, but
+/// for now, this hardcoded constant is probably reasonable.
+const ALLOC_LAYOUT: Layout =
+    unsafe { Layout::from_size_align_unchecked(READ_SIZE, BUFFER_ALIGNMENT) };
+
+/// How big our buffers are.
+///
+/// Later on we probably want to figure out how to auto-tune these values, but
+/// for now, this hardcoded constant is probably reasonable.
+const READ_SIZE: usize = 65536;
+
+/// What to align our buffer pages to.
+///
+/// Later on we probably want to figure out actual alignment values, but for
+/// now, this hardcoded constant is probably reasonable.
+const BUFFER_ALIGNMENT: usize = 16384;
 
 /// A worker thread ready to be moved onto a thread and started with the given
 /// [`Args`].

--- a/src/io_graph/worker/decompress.rs
+++ b/src/io_graph/worker/decompress.rs
@@ -1,15 +1,13 @@
 use std::{io::Read, marker::PhantomData};
 
-use bytes::BytesMut;
-
 use crate::{
     compression::{CompressionFormat, decompress},
-    io_graph::{GraphContext, RecvBytes, SendBytes, Worker, util::RecvBytesReader},
+    io_graph::{ALLOC_LAYOUT, GraphContext, RecvBytes, SendBytes, Worker, util::RecvBytesReader},
+    util::alloc_uninit_bytes_with_layout,
 };
 
 pub struct DecompressorWorker {
     cf: CompressionFormat,
-    read_size: usize,
     _phantom: PhantomData<()>,
 }
 
@@ -22,10 +20,9 @@ pub struct DecompressError {
 }
 
 impl DecompressorWorker {
-    pub fn new(cf: CompressionFormat, read_size: usize) -> Box<Self> {
+    pub fn new(cf: CompressionFormat) -> Box<Self> {
         Box::new(Self {
             cf,
-            read_size,
             _phantom: PhantomData,
         })
     }
@@ -46,14 +43,9 @@ impl<Rx: RecvBytes, Tx: SendBytes> Worker<(Rx, Tx)> for DecompressorWorker {
         let mut reader_empty = false;
 
         while !reader_empty {
-            // set up a new buffer
-            let mut buf = BytesMut::with_capacity(self.read_size);
-
             // SAFETY: these bytes will get filled up immediately. everything else that
             // wasn't filled up will get truncated
-            unsafe {
-                buf.set_len(self.read_size);
-            }
+            let mut buf = unsafe { alloc_uninit_bytes_with_layout(ALLOC_LAYOUT) };
 
             // fill up the buffer as much as possible
             let mut cursor = buf.as_mut();

--- a/src/io_graph/worker/file_reader.rs
+++ b/src/io_graph/worker/file_reader.rs
@@ -4,20 +4,20 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use bytes::BytesMut;
-
-use crate::io_graph::{SendBytes, Worker};
+use crate::{
+    io_graph::{ALLOC_LAYOUT, SendBytes, Worker},
+    util::alloc_uninit_bytes_with_layout,
+};
 
 /// A worker optimized for reading a file on disk.
 pub struct FileReader {
     path: PathBuf,
     size: u64,
-    read_size: usize,
     file: File,
 }
 
 impl FileReader {
-    pub fn new(path: &Path, read_size: usize) -> std::io::Result<Box<Self>> {
+    pub fn new(path: &Path) -> std::io::Result<Box<Self>> {
         let file = File::open(path)?;
         let size = file.metadata()?.len();
 
@@ -30,7 +30,6 @@ impl FileReader {
             size,
             path: path.to_owned(),
             file,
-            read_size,
         }))
     }
 
@@ -57,15 +56,9 @@ impl<Tx: SendBytes> Worker<Tx> for FileReader {
         let mut tx = args;
 
         while !context.halt() {
-            let mut buf = BytesMut::with_capacity(self.read_size);
-
-            // SAFETY: We are going to overwrite these bytes immediately.
-            // The bytes we don't read will get trimmed down to size.
-            // If you're concerned that the `File` impl may read these bytes, that's just
-            // way too paranoid.
-            unsafe {
-                buf.set_len(self.read_size);
-            }
+            // SAFETY: these bytes will get filled up immediately. everything else that
+            // wasn't filled up will get truncated
+            let mut buf = unsafe { alloc_uninit_bytes_with_layout(ALLOC_LAYOUT) };
 
             let count = self.file.read(&mut buf)?;
             if count == 0 {

--- a/src/stdiomux/common.rs
+++ b/src/stdiomux/common.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, pin::pin, rc::Rc};
 
-use bytes::{Bytes, BytesMut};
+use bytes::Bytes;
 use futures::{
     FutureExt as _, Stream, StreamExt as _, TryFutureExt as _, TryStreamExt,
     stream::{self, LocalBoxStream},
@@ -15,7 +15,10 @@ use tokio::{
 };
 use tracing::{Instrument as _, debug, debug_span, info_span, trace, trace_span};
 
-use crate::stdiomux::{BytestreamService, channel_map::ChannelMap};
+use crate::{
+    stdiomux::{BytestreamService, channel_map::ChannelMap},
+    util::alloc_uninit_bytes,
+};
 
 /// Returns a future for forwarding and multiplexing payloads over the provided
 /// rx and tx.
@@ -237,10 +240,8 @@ async fn read_msg(mut rx: impl AsyncRead + Unpin) -> Result<(u16, Option<Bytes>)
 
     tracing::trace!(?channel, ?len, "got message");
 
-    let mut msg = BytesMut::with_capacity(len);
-    unsafe {
-        msg.set_len(len);
-    }
+    // SAFETY: they get filled immediately
+    let mut msg = unsafe { alloc_uninit_bytes(len) };
     rx.read_exact(&mut msg)
         .instrument(trace_span!("read_exact"))
         .await?;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,6 +1,14 @@
 use std::{
-    env, fs::DirBuilder, os::unix::fs::DirBuilderExt as _, path::PathBuf, process, time::SystemTime,
+    alloc::{Layout, alloc},
+    env,
+    fs::DirBuilder,
+    os::unix::fs::DirBuilderExt as _,
+    path::PathBuf,
+    process,
+    time::SystemTime,
 };
+
+use bytes::{Bytes, BytesMut};
 
 pub mod candidate;
 
@@ -19,4 +27,32 @@ pub fn ensure_state_dir() -> std::io::Result<PathBuf> {
     DirBuilder::new().mode(0o700).recursive(true).create(&dir)?;
 
     Ok(dir)
+}
+
+/// Allocate a [BytesMut] with the given size and uninitialized contents.
+///
+/// Its capacity and length will both be set to this size.
+///
+/// This is marked as unsafe because the contents are uninitialized.
+pub unsafe fn alloc_uninit_bytes(len: usize) -> BytesMut {
+    let mut bytes = BytesMut::with_capacity(len);
+    unsafe {
+        bytes.set_len(len);
+    }
+    bytes
+}
+
+/// Allocate a [BytesMut] with the size and alignment of the given [Layout] and
+/// uninitialized contents.
+///
+/// Its capacity and length will both be set to the size of the [Layout].
+///
+/// This is marked as unsafe because the contents are uninitialized.
+pub unsafe fn alloc_uninit_bytes_with_layout(layout: Layout) -> BytesMut {
+    let len = layout.size();
+    let mem = unsafe {
+        let ptr = alloc(layout);
+        Vec::from_raw_parts(ptr, len, len).into_boxed_slice()
+    };
+    BytesMut::from(Bytes::from_owner(mem))
 }


### PR DESCRIPTION
## Summary

yea

## Type of change

<!-- Check boxes as applicable. Please add more options if you feel that they are relevant. -->

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] This change requires a documentation update
- [ ] This change contains modifications to the `--help` output
    - [ ] I ran `scripts/regenerate_readme.py` from the root directory to ensure it has the latest sample output

## Test plan

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. If you feel your change is minimal enough or already covered by automated tests, you can simply put "CI". -->

todo
